### PR TITLE
macOS: bzero the tqe in the allocation construction phase

### DIFF
--- a/module/os/macos/spl/spl-taskq.c
+++ b/module/os/macos/spl/spl-taskq.c
@@ -826,7 +826,7 @@ taskq_ent_constructor(void *buf, void *cdrarg, int kmflags)
 {
 	taskq_ent_t *tqe = buf;
 
-	tqe->tqent_thread = NULL;
+	bzero(tqe, sizeof (taskq_ent_t));
 	cv_init(&tqe->tqent_cv, NULL, CV_DEFAULT, NULL);
 #ifdef __APPLE__
 	/* Simulate TS_STOPPED */


### PR DESCRIPTION
macOS local (and first test of the PR mechanism on our fork): the tqent_next and tqent_prev fields are random, which causes problems with the IS_EMPTY() check, causing an assertion in zio_taskq_dispatch

