### PR TITLE
Fix an ABD kmem hashing bug

### DIFF
--- a/include/os/macos/spl/sys/debug.h
+++ b/include/os/macos/spl/sys/debug.h
@@ -139,7 +139,7 @@ void print_symbol(uintptr_t symbol);
 		if (!(_verify3_left OP _verify3_right))			\
 		    spl_panic(__FILE__, __FUNCTION__, __LINE__,		\
 		    "VERIFY3(" #LEFT " "  #OP " "  #RIGHT ") "		\
-		    "failed (%px " #OP " %px)\n",			\
+		    "failed (%p " #OP " %p)\n",			\
 		    (void *) (_verify3_left),				\
 		    (void *) (_verify3_right));				\
 	} while (0)

--- a/module/os/macos/spl/spl-kmem.c
+++ b/module/os/macos/spl/spl-kmem.c
@@ -1273,7 +1273,6 @@ kmem_slab_destroy(kmem_cache_t *cp, kmem_slab_t *sp)
 		}
 		kmem_cache_free(kmem_slab_cache, sp);
 	}
-	kpreempt(KPREEMPT_SYNC);
 	vmem_free_impl(vmp, slab, cp->cache_slabsize);
 }
 
@@ -1711,7 +1710,6 @@ kmem_magazine_destroy(kmem_cache_t *cp, kmem_magazine_t *mp, int nrounds)
 		}
 
 		kmem_slab_free(cp, buf);
-		kpreempt(KPREEMPT_SYNC);
 	}
 	ASSERT(KMEM_MAGAZINE_VALID(cp, mp));
 	kmem_cache_free(cp->cache_magtype->mt_cache, mp);
@@ -2496,7 +2494,6 @@ kmem_cache_free(kmem_cache_t *cp, const void *buf)
 		}
 	}
 	mutex_exit(&ccp->cc_lock);
-	kpreempt(KPREEMPT_SYNC);
 	kmem_slab_free_constructed(cp, __DECONST(void *, buf), B_TRUE);
 }
 
@@ -4267,7 +4264,6 @@ kmem_cache_build_slablist(kmem_cache_t *cp)
 		list_link_init(&fs->next);
 		list_insert_tail(&freelist, fs);
 	}
-
 
 	kstat_delete(cp->cache_kstat);
 

--- a/module/os/macos/spl/spl-seg_kmem.c
+++ b/module/os/macos/spl/spl-seg_kmem.c
@@ -289,9 +289,16 @@ segkmem_abd_init()
 
 	extern vmem_t *spl_heap_arena;
 
+#define	BIG_SLAB 131072
+#ifdef __arm64__
+#define	BIG_BIG_SLAB (BIG_SLAB * 2)
+#else
+#define	BIG_BIG_SLAB BIG_SLAB
+#endif
+
 	abd_arena = vmem_create("abd_cache", NULL, 0,
 	    PAGESIZE, vmem_alloc_impl, vmem_free_impl, spl_heap_arena,
-	    131072, VM_SLEEP | VMC_NO_QCACHE | VM_FIRSTFIT);
+	    BIG_BIG_SLAB, VM_SLEEP | VMC_NO_QCACHE | VM_FIRSTFIT);
 
 	VERIFY3P(abd_arena, !=, NULL);
 
@@ -306,8 +313,8 @@ segkmem_abd_init()
 	 */
 
 	abd_subpage_arena = vmem_create("abd_subpage_cache", NULL, 0,
-	    512, vmem_alloc_impl, vmem_free_impl, abd_arena,
-	    131072, VM_SLEEP | VMC_NO_QCACHE | VM_FIRSTFIT);
+	    sizeof (void *), vmem_alloc_impl, vmem_free_impl, spl_heap_arena,
+	    BIG_SLAB, VM_SLEEP | VMC_NO_QCACHE | VM_FIRSTFIT);
 
 	VERIFY3P(abd_subpage_arena, !=, NULL);
 }

--- a/module/os/macos/zfs/arc_os.c
+++ b/module/os/macos/zfs/arc_os.c
@@ -263,15 +263,6 @@ arc_reclaim_thread(void *unused)
 			manual_pressure = post_adjust_manual_pressure;
 		}
 
-		/*
-		 * If we have successfully freed a bunch of memory,
-		 * it is worth reaping the abd_chunk_cache
-		 */
-		if (d_adj >= 64LL*1024LL*1024LL) {
-			extern kmem_cache_t *abd_chunk_cache;
-			kmem_cache_reap_now(abd_chunk_cache);
-		}
-
 		free_memory = post_adjust_free_memory;
 
 		const hrtime_t curtime = gethrtime();


### PR DESCRIPTION
Detail in the commit itself.

* fix infrequent "bad free" panic
* bigger slab sizes in abd_chunk so abd_cache does less work
* minor abd perf improvements
* minor kmem perf improvements
* Divorce VERIFY3P's trailing "x"es
* cstyle