### PR TITLE
Some tidying up of atomics, wmsum as aggsum

### DIFF
--- a/include/os/macos/spl/sys/wmsum.h
+++ b/include/os/macos/spl/sys/wmsum.h
@@ -29,39 +29,41 @@
 #include <sys/systm.h>
 #include <sys/atomic.h>
 #include <sys/malloc.h>
+#include <sys/aggsum.h>
 
 #ifdef	__cplusplus
 extern "C" {
 #endif
 
-struct wmsum
-{
-	uint64_t wm_value;
-};
+/*
+ * Repeat what's in userland lib/libspl/include/sys/wmsum.h, as macOS does not
+ * have an API like the FreeBSD counter(9) or Linux's percpu_counter KPI.
+ */
 
-typedef struct wmsum wmsum_t;
+#define	wmsum_t	aggsum_t
 
 static inline void
 wmsum_init(wmsum_t *ws, uint64_t value)
 {
-	ws->wm_value = value;
+	aggsum_init(ws, value);
 }
 
 static inline void
 wmsum_fini(wmsum_t *ws)
 {
+	aggsum_fini(ws);
 }
 
 static inline uint64_t
 wmsum_value(wmsum_t *ws)
 {
-	return (atomic_add_64_nv(&ws->wm_value, 0));
+	return (aggsum_value(ws));
 }
 
 static inline void
 wmsum_add(wmsum_t *ws, int64_t delta)
 {
-	atomic_add_64(&ws->wm_value, delta);
+	aggsum_add(ws, delta);
 }
 
 #ifdef	__cplusplus

--- a/include/os/macos/zfs/sys/zfs_context_os.h
+++ b/include/os/macos/zfs/sys/zfs_context_os.h
@@ -29,6 +29,21 @@
 
 #include <sys/ldi_buf.h>
 
+#if !defined(MAC_OS_X_VERSION_10_12) || \
+	(MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_12)
+#define	os_cast_to_atomic_pointer(p) \
+	(__typeof__(*(p)) volatile _Atomic *)(uintptr_t)(p)
+#define	atomic_store(object, desired) \
+	__c11_atomic_store(object, desired, __ATOMIC_SEQ_CST)
+#define	atomic_load(object) __c11_atomic_load(object, __ATOMIC_SEQ_CST)
+#define	atomic_fetch_add(object, operand) \
+	__c11_atomic_fetch_add(object, operand, __ATOMIC_SEQ_CST)
+#define	atomic_fetch_sub(object, operand) \
+	__c11_atomic_fetch_sub(object, operand, __ATOMIC_SEQ_CST)
+#else
+#include <os/atomic.h>
+#endif
+
 #define	ZIO_OS_FIELDS \
 	struct { \
 		ldi_buf_t	zm_buf; \
@@ -112,31 +127,12 @@ struct hlist_head {
 	struct hlist_node *first;
 };
 
-typedef struct {
-	volatile int counter;
-} atomic_t;
+typedef int atomic_t;
 
 #define	ACCESS_ONCE(x) (*(volatile typeof(x) *)&(x))
 
 #define	barrier()		__asm__ __volatile__("": : :"memory")
 #define	smp_rmb()		barrier()
-
-#define	READ_ONCE(x) ( \
-{	\
-			__typeof(x) __var = ( \
-					{	\
-					barrier();	\
-					ACCESS_ONCE(x);	\
-				});	\
-			barrier();	\
-			__var;	\
-		})
-
-#define	WRITE_ONCE(x, v) do { \
-		barrier();  \
-		ACCESS_ONCE(x) = (v);	\
-		barrier();	\
-	} while (0)
 
 /* BEGIN CSTYLED */
 #define	hlist_for_each(p, head)	\
@@ -145,20 +141,23 @@ typedef struct {
 #define	hlist_entry(ptr, type, field)   container_of(ptr, type, field)
 /* END CSTYLED */
 
+#define	WRITE_ONCE_PTR(x, n) atomic_store( \
+	    os_cast_to_atomic_pointer(x), (n))
+
 static inline void
 hlist_add_head(struct hlist_node *n, struct hlist_head *h)
 {
 	n->next = h->first;
 	if (h->first != NULL)
 		h->first->pprev = &n->next;
-	WRITE_ONCE(h->first, n);
+	WRITE_ONCE_PTR(&h->first, n);
 	n->pprev = &h->first;
 }
 
 static inline void
 hlist_del(struct hlist_node *n)
 {
-	WRITE_ONCE(*(n->pprev), n->next);
+	WRITE_ONCE_PTR(n->pprev, n->next);
 	if (n->next != NULL)
 		n->next->pprev = n->pprev;
 }
@@ -180,19 +179,20 @@ hlist_del(struct hlist_node *n)
 static inline int
 atomic_read(const atomic_t *v)
 {
-	return (READ_ONCE(v->counter));
+	barrier();
+	return (atomic_load(os_cast_to_atomic_pointer(v)));
 }
 
 static inline int
 atomic_inc(atomic_t *v)
 {
-	return (__sync_fetch_and_add(&v->counter, 1) + 1);
+	return (1 + atomic_fetch_add(os_cast_to_atomic_pointer(v), 1));
 }
 
 static inline int
 atomic_dec(atomic_t *v)
 {
-	return (__sync_fetch_and_add(&v->counter, -1) - 1);
+	return (-1 + atomic_fetch_sub(os_cast_to_atomic_pointer(v), 1));
 }
 
 extern void spl_qsort(void *array, size_t nm, size_t member_size,


### PR DESCRIPTION
The atomics in the macos zfs_context_os.h followed FreeBSD's and/or Linux's approach.   We can do better, since we are unafraid of C11 atomics in 2023. :-)

This lets us drop typedef struct { int counter } atomic_t in favour of just an int; this saves on register pressure, makes understanding the scope of the atomic operation cleaner, and so forth.  In turn, C type casting madness requires the WRITE_ONCE macro (used only internally in the .h file) to take a different type in the first argument.

Finally, follow userland and have wmsum be aggsum, which turns out to have better fan-out (notably, locks are placed on different cache lines) of the atomic operations on the stats counters that use them than just doing atomic updates.