### PR TITLE
Infrequent printf/ASSERT in thread-call vmem allocator and other fixes

### DIFF
--- a/include/os/macos/spl/sys/atomic.h
+++ b/include/os/macos/spl/sys/atomic.h
@@ -388,6 +388,25 @@ membar_consumer(void)
 	__c11_atomic_thread_fence(__ATOMIC_ACQ_REL);
 }
 
+/*
+ * Macro versions of full barrier.
+ *
+ * This is used to guard against possibly insufficiently-strong acquire
+ * semantics in the xnu calls to lck_mtx_{lock,unlock} and msleep in
+ * mutex_{enter,exit} resp. cv_wait\*.  It is not expensive on Apple Silicon
+ * in our code base, but it's unnecessary in x86-64.
+ *
+ * xcode clang on Apple Silicon will make this a "dmb ish" and take care about
+ * its own ordering of operations.  This provides an interproccessor total
+ * happens-before/happens-after ordering that x86-64 (and in the past, Sparc
+ * with TSO, total store ordering) gives us by default.
+ */
+#ifdef __arm64__
+#define	spl_data_barrier()	__atomic_thread_fence(__ATOMIC_SEQ_CST)
+#else
+#define	spl_data_barrier()	do {} while (0)
+#endif
+
 #ifdef	__cplusplus
 }
 #endif

--- a/include/os/macos/spl/sys/vmem_impl.h
+++ b/include/os/macos/spl/sys/vmem_impl.h
@@ -126,12 +126,17 @@ typedef struct thread_call *thread_call_t;
 
 /* parameters passed between thread_call threads */
 typedef struct cb_params {
-	boolean_t	in_child;	/* set in worker callback function */
-	boolean_t	already_pending; /* sanity check thread_call_enter1() */
-	size_t		size;
-	int		vmflag;
-	void		*r_alloc;	/* vmem_alloc() return value */
-	boolean_t	c_done;		/* flag worker callback is done */
+	/* has the worker thread been entered? */
+	_Atomic boolean_t	in_child;
+	/* sanity check on thread_call_enter1() behaviour */
+	_Atomic boolean_t	already_pending;
+	/* how much to allocate, what vmem_alloc_impl() flags to use */
+	_Atomic size_t		size;
+	int			vmflag;
+	/* wrapped_vmem_alloc_impl() return value */
+	void			*r_alloc;
+	/* has the worker thread finished? */
+	_Atomic boolean_t	c_done;
 } cb_params_t;
 
 struct vmem {

--- a/module/os/macos/spl/spl-seg_kmem.c
+++ b/module/os/macos/spl/spl-seg_kmem.c
@@ -301,11 +301,11 @@ segkmem_abd_init()
 	if (total_memory >= SMALL_RAM_MACHINE) {
 		abd_arena = vmem_create("abd_cache", NULL, 0,
 		    PAGESIZE, vmem_alloc_impl, vmem_free_impl, spl_heap_arena,
-		    BIG_BIG_SLAB, VM_SLEEP | VMC_NO_QCACHE | VM_FIRSTFIT);
+		    BIG_BIG_SLAB, VM_SLEEP | VMC_NO_QCACHE);
 	} else {
 		abd_arena = vmem_create("abd_cache", NULL, 0,
 		    PAGESIZE, vmem_alloc_impl, vmem_free_impl, spl_heap_arena,
-		    131072, VM_SLEEP | VMC_NO_QCACHE | VM_FIRSTFIT);
+		    131072, VM_SLEEP | VMC_NO_QCACHE);
 	}
 
 	VERIFY3P(abd_arena, !=, NULL);
@@ -324,11 +324,11 @@ segkmem_abd_init()
 		abd_subpage_arena = vmem_create("abd_subpage_cache", NULL, 0,
 		    sizeof (void *), vmem_alloc_impl, vmem_free_impl,
 		    spl_heap_arena,
-		    BIG_SLAB, VM_SLEEP | VMC_NO_QCACHE | VM_FIRSTFIT);
+		    BIG_SLAB, VM_SLEEP | VMC_NO_QCACHE);
 	} else {
 		abd_subpage_arena = vmem_create("abd_subpage_cache", NULL, 0,
 		    512, vmem_alloc_impl, vmem_free_impl, abd_arena,
-		    131072, VM_SLEEP | VMC_NO_QCACHE | VM_FIRSTFIT);
+		    131072, VM_SLEEP | VMC_NO_QCACHE);
 	}
 
 	VERIFY3P(abd_subpage_arena, !=, NULL);

--- a/module/os/macos/zfs/abd_os.c
+++ b/module/os/macos/zfs/abd_os.c
@@ -410,7 +410,7 @@ abd_init(void)
 
 #ifdef _KERNEL
 /* This must all match spl-seg_kmem.c : segkmem_abd_init() */
-#define	SMALL_RAM_MACHINE (4096ULL * 1024ULL * 1024ULL * 1024ULL)
+#define	SMALL_RAM_MACHINE (4ULL * 1024ULL * 1024ULL * 1024ULL)
 
 	extern uint64_t total_memory;
 


### PR DESCRIPTION
Stacks that allocate memory can go quite deep when a kmem_cache needs a new slab from its parent vmem arena, which needs a new import from its parent arena, which, ..., and which calls IOMallocAligned() which makes further calls, etc.   Consequently we have a wrapper around vmem_alloc() which examines the current stack depth and if there isn't ample stack remaining, it will satisfy the allocation in a worker thread.  That's implemented using xnu's thread_call API rather than a taskq in strict fifo mode, in order to simplify the critical sections and to avoid secondary memory allocations.

The calling thread obtains  an address from the worker thread and returns it after dropping locks.  Unfortunately those locks protected the memory location of the returned data, opening a data race that might lead to a NULL being returned (which is not fatal to the caller) or in exceptional circumstances returning a different non-NULL address obtained by another thread with a deep stack concurrently wanting memory from the same arena.  The duplicate address is likely to cause a panic eventually.

The "protocol" between the thread needing memory and the worker thread involves cv_timedwait() in the parent and a cv_signal() in the worker thread.  The cv_timedwait() could be skipped over as a shortcut in the caller, but the worker thread still sent a cv_signal() to the condvar.   On macOS, cv_signal() sent when nothing is in cv_\*wait\*() on the condvar can cause the next cv_\*wait\*() on that condvar to return immediately, even if the cv_signal() was sent considerably before the cv_\*wait\*().  The shortcut triggered this.   

All of the above is harder to analyse and riskier in high-concurrency on Apple Silicon because of its weak memory model; Intel processors have a total ordering that's even stronger than Sparc's TSO (total store ordering).   Callers of cv_\*wait\*() are warned in the illumos man page that the functions may return prematurely and the reason for the blocking call should therefore be re-checked.   This was being done by the thread calling the worker, but it printf()ed the unexpectedly early return.   Investigating the race above led to some additional data barriers for Apple Silicon designed to enforce a happens-before/happens-after ordering at mutex_{enter,exit}() [really the call to lck_mtx_\*()] and cv_\*wait\*() [really msleep()] edges.

Finally, fixes and improvements in the creation of the abd kmem caches and vmem arena.


