### PR TITLE
RFR Further deprioritize ZIO_PRIORITY_SCRUB and dsl_scan threads

### DIFF
--- a/include/os/macos/spl/sys/mutex.h
+++ b/include/os/macos/spl/sys/mutex.h
@@ -149,6 +149,10 @@ struct thread *spl_mutex_owner(kmutex_t *mp);
 int  spl_mutex_subsystem_init(void);
 void spl_mutex_subsystem_fini(void);
 
+extern lck_grp_attr_t	*spl_mtx_grp_attr;
+extern lck_attr_t	*spl_mtx_lck_attr;
+extern lck_grp_t	*spl_mtx_grp;
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/os/macos/spl/sys/sysmacros.h
+++ b/include/os/macos/spl/sys/sysmacros.h
@@ -114,7 +114,13 @@ extern unsigned int num_ecores;
 #define	minclsyspri  70 /* well below the render server and other graphics */
 #define	defclsyspri  75 /* five below the xnu kernel services */
 #define	maxclsyspri  80 /* 1 less than base, 2 less than networking */
-#define	dsl_scan_iss_syspri	(minclsyspri - 1)
+/*
+ * taskqs for scrubs can be lower-priority, and are better that way for wide
+ * pools (where the number of vdevs is 50% or more the number of cores).
+ *
+ * This value is around the level of bluetoothd or userland audio
+ */
+#define	dsl_scan_iss_syspri	60
 
 /*
  * Missing macros

--- a/include/os/macos/spl/sys/thread.h
+++ b/include/os/macos/spl/sys/thread.h
@@ -145,8 +145,6 @@ extern void set_thread_timeshare_named(thread_t,
     const char *);
 extern void set_thread_timeshare(thread_t);
 
-extern void spl_throttle_set_thread_io_policy(int);
-
 #define	delay osx_delay
 extern void osx_delay(int);
 

--- a/include/os/macos/spl/sys/thread.h
+++ b/include/os/macos/spl/sys/thread.h
@@ -77,25 +77,55 @@ typedef void (*thread_func_t)(void *);
 
 #ifdef SPL_DEBUG_THREAD
 
-#define	thread_create(A, B, C, D, E, F, G, H) \
+#define	thread_create(A, B, C, D, E, F, G, H)			\
     spl_thread_create_named(__FILE__, A, B, C, D, E, G, __FILE__, __LINE__, H)
 #define	thread_create_named(name, A, B, C, D, E, F, G, H)	\
     spl_thread_create_named(name, A, B, C, D, E, G, __FILE__, __LINE__, H)
+#define	thread_create_named_with_extpol_and_qos(name,		\
+    S, T, Q, A, B, C, D, E, F, G)				\
+	spl_thread_create_named_with_extpol_and_qos(S, T, Q,	\
+	    name, A, B, C, D, E, F,  __FILE__, __LINE__, G)
 
 extern kthread_t *spl_thread_create_named(const char *name,
     caddr_t stk, size_t stksize,
-    void (*proc)(void *), void *arg, size_t len, /* proc_t *pp, */ int state,
+    thread_func_t proc, void *arg, size_t len, /* proc_t *pp, */ int state,
+    const char *, int, pri_t pri);
+
+extern kthread_t *spl_thread_create_named_with_extpol_and_qos(
+    thread_extended_policy_t tmsharepol,
+    thread_throughput_qos_policy_t thoughpol,
+    thread_latency_qos_t latpol,
+    const char *name,
+    caddr_t stk, size_t stksize,
+    thread_func_t proc, void *arg, size_t len, /* proc_t *pp, */ int state,
     const char *, int, pri_t pri);
 
 #else
 
-#define	thread_create(A, B, C, D, E, F, G, H) \
-    spl_thread_create_named(__FILE__, A, B, C, D, E, G, H)
+#define	thread_create(A, B, C, D, E, F, G, H)			\
+	spl_thread_create_named(__FILE__, A, B, C, D, E, G, H)
 #define	thread_create_named(name, A, B, C, D, E, F, G, H)	\
-    spl_thread_create_named(name, A, B, C, D, E, G, H)
+	spl_thread_create_named(name, A, B, C, D, E, G, H)
+#define	thread_create_named_with_extpol_and_qos(name,		\
+    S, T, Q, A, B, C, D, E, F, G)				\
+	spl_thread_create_named_with_extpol_and_qos(		\
+	    S, T, Q, name, A, B, C, D, E, F, G)
+
 extern kthread_t *spl_thread_create_named(const char *name,
     caddr_t stk, size_t stksize,
-    void (*proc)(void *), void *arg, size_t len, /* proc_t *pp, */ int state,
+    thread_func_t proc, void *arg, size_t len,
+	/* proc_t *pp, */
+    int state,
+    pri_t pri);
+
+extern kthread_t *spl_thread_create_named_with_extpol_and_qos(
+    thread_extended_policy_t tmsharepol,
+    thread_throughput_qos_policy_t thoughpol,
+    thread_latency_qos_policy_t latpol,
+    const char *name,
+    caddr_t stk, size_t stksize,
+    thread_func_t proc,
+    void *arg, size_t len, /* proc_t *pp, */ int state,
     pri_t pri);
 
 #endif
@@ -128,22 +158,16 @@ extern void spl_thread_exit(void) __attribute__((noreturn));
 
 extern kthread_t *spl_current_thread(void);
 
-extern void set_thread_importance_named(thread_t, pri_t, const char *);
-extern void set_thread_importance(thread_t, pri_t);
+extern void spl_set_thread_importance(thread_t, pri_t, const char *);
 
-extern void set_thread_throughput_named(thread_t,
-    thread_throughput_qos_t, const char *);
-extern void set_thread_throughput(thread_t,
-    thread_throughput_qos_t);
+extern void spl_set_thread_timeshare(thread_t,
+    thread_extended_policy_data_t *, const char *);
 
-extern void set_thread_latency_named(thread_t,
-    thread_latency_qos_t, const char *);
-extern void set_thread_latency(thread_t,
-    thread_latency_qos_t);
+extern void spl_set_thread_throughput(thread_t,
+    thread_throughput_qos_policy_data_t *, const char *);
 
-extern void set_thread_timeshare_named(thread_t,
-    const char *);
-extern void set_thread_timeshare(thread_t);
+extern void spl_set_thread_latency(thread_t,
+    thread_latency_qos_policy_data_t *, const char *);
 
 #define	delay osx_delay
 extern void osx_delay(int);

--- a/module/os/macos/spl/spl-mutex.c
+++ b/module/os/macos/spl/spl-mutex.c
@@ -39,6 +39,13 @@
 // Not defined in headers
 extern boolean_t lck_mtx_try_lock(lck_mtx_t *lck);
 
+/*
+ * SPL mutexes: use the XNU interface, rather than the ones below,
+ * initialized in spl-osx.c and used in spl-thread.c
+ */
+lck_grp_attr_t	*spl_mtx_grp_attr;
+lck_attr_t	*spl_mtx_lck_attr;
+lck_grp_t	*spl_mtx_grp;
 
 static lck_attr_t	*zfs_lock_attr = NULL;
 static lck_grp_attr_t	*zfs_group_attr = NULL;
@@ -148,13 +155,14 @@ spl_mutex_subsystem_init(void)
 	mutex_list_mutex.m_initialised = MUTEX_INIT;
 	cv_init(&mutex_list_cv, NULL, CV_DEFAULT, NULL);
 
-	(void) thread_create(NULL, 0, spl_wdlist_check, 0, 0, 0, 0,
-	    maxclsyspri);
-#endif
+	/* create without timesharing or qos */
+	(void) thread_create_named_with_extpol_and_qos(
+	    "spl_wdlist_check (mutex)",
+	    NULL, NULL, NULL,
+	    NULL, 0, spl_wdlist_check, NULL, 0, 0, maxclsyspri);
+#endif /* SPL_DEBUG_MUTEX */
 	return (0);
 }
-
-
 
 void
 spl_mutex_subsystem_fini(void)

--- a/module/os/macos/spl/spl-osx.c
+++ b/module/os/macos/spl/spl-osx.c
@@ -435,6 +435,15 @@ spl_start(kmod_info_t *ki, void *d)
 		delay(hz>>1);
 	}
 
+	/*
+	 * special purpose xnu-style locks, separate from the spl-mutex.c
+	 * system, where those are available either late or may require
+	 * memory or thread allocation
+	 */
+	spl_mtx_lck_attr  = lck_attr_alloc_init();
+	spl_mtx_grp_attr = lck_grp_attr_alloc_init();
+	spl_mtx_grp = lck_grp_alloc_init("spl-mutex", spl_mtx_grp_attr);
+
 	while (1) {
 		len = sizeof (total_memory);
 		sysctlbyname("hw.memsize", &total_memory, &len, NULL, 0);
@@ -541,6 +550,13 @@ spl_stop(kmod_info_t *ki, void *d)
 	spl_kmem_fini();
 	spl_kstat_fini();
 	spl_mutex_subsystem_fini();
+
+	lck_attr_free(spl_mtx_lck_attr);
+	spl_mtx_lck_attr = NULL;
+	lck_grp_attr_free(spl_mtx_grp_attr);
+	spl_mtx_grp_attr = NULL;
+	lck_grp_free(spl_mtx_grp);
+	spl_mtx_grp = NULL;
 
 	return (KERN_SUCCESS);
 }

--- a/module/os/macos/spl/spl-taskq.c
+++ b/module/os/macos/spl/spl-taskq.c
@@ -1868,145 +1868,159 @@ taskq_thread_wait(taskq_t *tq, kmutex_t *mx, kcondvar_t *cv,
 }
 
 #ifdef __APPLE__
-/*
- * Adjust thread policies for SYSDC and BATCH task threads
- */
 
 /*
- * from osfmk/kern/thread.[hc] and osfmk/kern/ledger.c
- *
- * limit [is] a percentage of CPU over an interval in nanoseconds
- *
- * in particular limittime = (interval_ns * percentage) / 100
- *
- * when a thread has enough cpu time accumulated to hit limittime,
- * ast_taken->thread_block is seen in a stackshot (e.g. spindump)
- *
- * thread.h 204:#define MINIMUM_CPULIMIT_INTERVAL_MS 1
- *
- * Illumos's sysdc updates its stats every 20 ms
- * (sysdc_update_interval_msec)
- * which is the tunable we can deal with here; xnu will
- * take care of the bookkeeping and the amount of "break",
- * which are the other Illumos tunables.
+ * Create a thread with appropriate importance and QOS
  */
-#define	CPULIMIT_INTERVAL (MSEC2NSEC(100ULL))
-#define	THREAD_CPULIMIT_BLOCK 0x1
 
-static void
-taskq_thread_set_cpulimit(taskq_t *tq)
+static kthread_t *
+spl_taskq_thread_create_named(const char *name,
+    taskq_t *tq,
+    caddr_t stk,
+    size_t stksize,
+    thread_func_t proc,
+    void *arg,
+    size_t len,
+    int state,
+    pri_t pri)
 {
-	if (tq->tq_flags & TASKQ_DUTY_CYCLE) {
+
+	kthread_t *new_thread = NULL;
+	/*
+	 * We pass pri along, but use it to determine
+	 * what QOS to pass along as well
+	 */
+
+	if (pri < minclsyspri) {
+		/*
+		 * these are dsl_scan asynchronous reads,
+		 * and need neither QOS nor timesharing
+		 */
+		thread_extended_policy_data_t timeshare = {
+			.timeshare = 0,
+		};
+		new_thread =
+		    spl_thread_create_named_with_extpol_and_qos(
+		    &timeshare, NULL, NULL,
+		    name, stk, stksize, proc, arg, len, state, pri);
+	} else if (tq->tq_maxsize == 1 &&
+	    (tq->tq_flags & (TASKQ_DYNAMIC
+	    | TASKQ_THREADS_CPU_PCT
+	    | TASKQ_DUTY_CYCLE
+	    | TASKQ_DC_BATCH)) == 0) {
+		/*
+		 * This is a strict-FIFO taskq, which should be held at a
+		 * stable priority so that the immediately previous job on
+		 * this sole worker thread has not left the scheduler with the
+		 * wrong opinion of the job that is to come.  TIMESHARE could
+		 * let a well-behaved previous job might lead to an
+		 * over-prioritization of the subsequent job.
+		 */
+		thread_extended_policy_data_t timeshare = {
+			.timeshare = 0,
+		};
+		new_thread =
+		    spl_thread_create_named_with_extpol_and_qos(
+		    &timeshare, NULL, NULL,
+		    name, stk, stksize, proc, arg, len, state, pri);
+	} else if (tq->tq_flags & TASKQ_DC_BATCH) {
+		/*
+		 * Batch SDC scheduling class,
+		 * CPU intensive but not latency sensitive
+		 */
 		ASSERT3U(tq->tq_DC, <=, 100);
 		ASSERT3U(tq->tq_DC, >, 0);
 
-		int ret = 45; // ENOTSUP -- XXX todo: drop priority?
+		int pri_pct = (maxclsyspri * tq->tq_DC) / 100 - 1;
+		if (pri_pct < minclsyspri)
+			pri_pct = minclsyspri;
+		if (pri_pct >= maxclsyspri)
+			pri_pct = maxclsyspri - 1;
 
-		if (ret != KERN_SUCCESS) {
-			printf("SPL: %s:%d: WARNING"
-			    " thread_set_cpulimit returned %d\n",
-			    __func__, __LINE__, ret);
+		thread_throughput_qos_policy_data_t throughpol = {
+			.thread_throughput_qos_tier =
+			THROUGHPUT_QOS_TIER_2,
+		};
+
+		thread_latency_qos_policy_data_t latpol = {
+			.thread_latency_qos_tier =
+			LATENCY_QOS_TIER_3,
+		};
+
+		thread_extended_policy_data_t timeshare = {
+			.timeshare = 0,
+		};
+
+		new_thread =
+		    spl_thread_create_named_with_extpol_and_qos(
+		    &timeshare, &throughpol, &latpol,
+		    name, stk, stksize, proc, arg, len, state, pri_pct);
+	} else if (tq->tq_flags & TASKQ_DUTY_CYCLE) {
+		/*
+		 * SDC scheduling class, the sysdc threads.
+		 * This is cpu-intensive workload.
+		 * We need the "duty cycle" (DC)
+		 * from tq->tq_DC, which is a percentage
+		 * of CPU
+		 */
+		ASSERT3U(tq->tq_DC, <=, 100);
+		ASSERT3U(tq->tq_DC, >, 0);
+
+		thread_throughput_qos_t tqos;
+
+		int pri_pct = (maxclsyspri * tq->tq_DC) / 100 - 1;
+		if (pri_pct < minclsyspri)
+			pri_pct = minclsyspri;
+		if (pri_pct >= maxclsyspri)
+			pri_pct = maxclsyspri - 1;
+
+		if (pri < defclsyspri) {
+			tqos = THROUGHPUT_QOS_TIER_4;
+		} else if (pri < maxclsyspri) {
+			tqos = THROUGHPUT_QOS_TIER_3;
+		} else {
+			tqos = THROUGHPUT_QOS_TIER_2;
 		}
+
+		thread_throughput_qos_policy_data_t throughpol = {
+			.thread_throughput_qos_tier = tqos,
+		};
+
+		/* no latency, default timeshare */
+		new_thread =
+		    spl_thread_create_named_with_extpol_and_qos(
+		    NULL, &throughpol, NULL,
+		    name, stk, stksize, proc, arg, len, state, pri_pct);
+	} else if (pri < maxclsyspri) {
+		/* just a default thread */
+		new_thread =
+		    spl_thread_create_named_with_extpol_and_qos(
+		    NULL, NULL, NULL,
+		    name, stk, stksize, proc, arg, len, state, pri);
+	} else {
+		/*
+		 * maxclsyspri, low latency ("LEGACY" aka "USER_INITIATED")
+		 */
+
+		thread_latency_qos_policy_data_t latpol = {
+			.thread_latency_qos_tier =
+			LATENCY_QOS_TIER_1,
+		};
+
+		new_thread =
+		    spl_thread_create_named_with_extpol_and_qos(
+		    NULL, NULL, &latpol,
+		    name, stk, stksize, proc, arg, len, state, pri);
 	}
-}
-
-/*
- * Set up xnu thread importance,
- * throughput and latency QOS.
- *
- * Approximate Illumos's SYSDC
- * (/usr/src/uts/common/disp/sysdc.c)
- *
- * SYSDC tracks cpu runtime itself, and yields to
- * other threads if
- * onproc time / (onproc time + runnable time)
- * exceeds the Duty Cycle threshold.
- *
- * Approximate this by
- * [a] setting a thread_cpu_limit percentage,
- * [b] setting the thread precedence
- * slightly higher than normal,
- * [c] setting the thread throughput and latency policies
- * just less than USER_INTERACTIVE, and
- * [d] turning on the
- * TIMESHARE policy, which adjusts the thread
- * priority based on cpu usage.
- */
-
-static void
-set_taskq_thread_attributes(thread_t thread, taskq_t *tq)
-{
-	pri_t pri = tq->tq_pri;
-
-	/*
-	 * Timeshare lets the system adjust the priority up or down depending
-	 * on system activity; on newer macOS this is the default behaviour
-	 * and is a good choice for us practically always, the exception
-	 * being very low-priority threads (scrub-related)
-	 */
-	if (pri >= minclsyspri)
-		set_thread_timeshare_named(thread,
-		    tq->tq_name);
-
-	if (tq->tq_flags & TASKQ_DUTY_CYCLE) {
-		taskq_thread_set_cpulimit(tq);
+	if (!new_thread) {
+		printf("SPL: %s:%s:%d: unable to create thread"
+		    " '%s', pri %d, DC %d, flags %x\n",
+		    __FILE__, __func__, __LINE__,
+		    (name == NULL) ? "unammed tq thread" : name,
+		    pri, tq->tq_DC, tq->tq_flags);
 	}
 
-	if (tq->tq_flags & TASKQ_DC_BATCH)
-		pri--;
-
-	set_thread_importance_named(thread,
-	    pri, tq->tq_name);
-
-	/*
-	 * TIERs: 0 is USER_INTERACTIVE, 1 is USER_INITIATED, 1 is LEGACY,
-	 *        2 is UTILITY, 5 is BACKGROUND, 5 is MAINTENANCE
-	 */
-	const thread_throughput_qos_t std_throughput = THROUGHPUT_QOS_TIER_1;
-	const thread_throughput_qos_t sysdc_throughput = THROUGHPUT_QOS_TIER_1;
-	const thread_throughput_qos_t batch_throughput = THROUGHPUT_QOS_TIER_2;
-	const thread_throughput_qos_t minpri_throughput = batch_throughput;
-	const thread_throughput_qos_t dsl_scan_iss_throughput =
-	    THROUGHPUT_QOS_TIER_5;
-
-	if (tq->tq_flags & TASKQ_DC_BATCH)
-		set_thread_throughput_named(thread,
-		    batch_throughput, tq->tq_name);
-	else if (tq->tq_flags & TASKQ_DUTY_CYCLE)
-		set_thread_throughput_named(thread,
-		    sysdc_throughput, tq->tq_name);
-	else if (pri == minclsyspri)
-		set_thread_throughput_named(thread,
-		    minpri_throughput, tq->tq_name);
-	else if (pri < minclsyspri)
-		set_thread_throughput_named(thread,
-		    dsl_scan_iss_throughput, tq->tq_name);
-	else
-		set_thread_throughput_named(thread,
-		    std_throughput, tq->tq_name);
-
-	/*
-	 * TIERs: 0 is USER_INTERACTIVE, 1 is USER_INITIATED,
-	 *        1 is LEGACY, 3 is UTILITY, 3 is BACKGROUND,
-	 *        5 is MAINTENANCE
-	 */
-	const thread_latency_qos_t batch_latency = LATENCY_QOS_TIER_3;
-	const thread_latency_qos_t std_latency = LATENCY_QOS_TIER_1;
-	const thread_latency_qos_t minpri_latency = batch_latency;
-	const thread_latency_qos_t dsl_scan_iss_latency = LATENCY_QOS_TIER_5;
-
-	if (tq->tq_flags & TASKQ_DC_BATCH)
-		set_thread_latency_named(thread,
-		    batch_latency, tq->tq_name);
-	else if (pri == minclsyspri)
-		set_thread_latency_named(thread,
-		    minpri_latency, tq->tq_name);
-	else if (pri < minclsyspri)
-		set_thread_latency_named(thread,
-		    dsl_scan_iss_latency, tq->tq_name);
-	else
-		set_thread_latency_named(thread,
-		    std_latency, tq->tq_name);
+	return (new_thread);
 }
 
 #endif // __APPLE__
@@ -2024,10 +2038,6 @@ taskq_thread(void *arg)
 	callb_cpr_t cprinfo;
 	hrtime_t start, end;
 	boolean_t freeit;
-
-#ifdef __APPLE__
-	set_taskq_thread_attributes(current_thread(), tq);
-#endif
 
 	CALLB_CPR_INIT(&cprinfo, &tq->tq_lock, callb_generic_cpr,
 	    tq->tq_name);
@@ -2763,11 +2773,10 @@ taskq_bucket_extend(void *arg)
 	 * for it to be initialized (below).
 	 */
 	tqe->tqent_thread = (kthread_t *)0xCEDEC0DE;
-	thread = thread_create_named(tq->tq_name,
-	    NULL, 0, (void (*)(void *))taskq_d_thread,
-	    tqe, 0, pp0, TS_RUN, tq->tq_pri);
 
-	set_taskq_thread_attributes(thread, tq);
+	thread = spl_taskq_thread_create_named(tq->tq_name,
+	    tq, NULL, 0, (thread_func_t)taskq_d_thread, tqe,
+	    0, TS_RUN, tq->tq_pri);
 #else
 
 	/*

--- a/module/os/macos/spl/spl-thread.c
+++ b/module/os/macos/spl/spl-thread.c
@@ -120,24 +120,14 @@ timeout_generic(int type, void (*func)(void *), void *arg,
 	return ((callout_id_t)arg);
 }
 
-#if defined(MACOS_IMPURE)
-extern void throttle_set_thread_io_policy(int priority);
-#endif
-
-void
-spl_throttle_set_thread_io_policy(int priority)
-{
-#if defined(MACOS_IMPURE)
-	throttle_set_thread_io_policy(priority);
-#endif
-}
-
-
 /*
  * Set xnu kernel thread importance based on openzfs pri_t.
  *
- * Thread importance adjusts upwards and downards from
- * BASEPRI_KERNEL (defined as 81).
+ * Thread importance adjusts upwards and downards from BASEPRI_KERNEL (defined
+ * as 81).  Higher value is higher priority (e.g. BASEPRI_REALTIME is 96),
+ * BASEPRI_GRAPHICS is 76, and MAXPRI_USER is 63.
+ *
+ * (See osfmk/kern/sched.h)
  *
  * Many important kernel tasks run at BASEPRI_KERNEL,
  * with networking and kernel graphics (Metal etc) running
@@ -160,15 +150,27 @@ set_thread_importance_named(thread_t thread, pri_t pri, const char *name)
 	/*
 	 * start by finding an offset from BASEPRI_KERNEL,
 	 * which is found in osfmk/kern/sched.h
+	 *
+	 * (it's 81, importance is a signed-offset from that)
 	 */
 
 	policy.importance = pri - 81;
 
-	/* dont let ANY of our threads run as high as networking & GPU */
+	/*
+	 * dont let ANY of our threads run as high as networking & GPU
+	 *
+	 * hard cap on our maximum priority at 81 (BASEPRI_KERNEL),
+	 * which is then our maxclsyspri.
+	 */
 	if (policy.importance > 0)
 		policy.importance = 0;
-	else if (policy.importance < (-11))
-		policy.importance = -11;
+	/*
+	 * set a floor on importance at priority 60, which is about the same
+	 * as bluetoothd and userland audio, which are of relatively high
+	 * importance.
+	 */
+	else if (policy.importance < (-21))
+		policy.importance = -21;
 
 	int i = policy.importance;
 	kern_return_t pol_prec_kret = thread_policy_set(thread,

--- a/module/os/macos/zfs/ldi_iokit.cpp
+++ b/module/os/macos/zfs/ldi_iokit.cpp
@@ -1365,7 +1365,7 @@ buf_strategy_iokit(ldi_buf_t *lbp, struct ldi_handle *lhp)
 	}
 
 	if (lbp->b_flags & B_THROTTLED_IO) {
-		ioattr.priority = kIOStoragePriorityLow;
+		ioattr.priority = kIOStoragePriorityBackground - 1;
 	}
 
 	if (lbp->b_flags & B_FUA) {


### PR DESCRIPTION
Some tidying up after the priority lowering of scrub-related threads.

In particular, fix the floor priority our threads would use to accomodate threads at lower priority than minclsyspri.

Also, use a background IOStorage priority rather than kIOStoragePriorityLow; this is more in line with the IOKit documentation and source code.

Remove some old MACOS_IMPURE code since nobody uses that any more.  It might not even be usable, it certainly hasn't been tested.

Did some significant reworking of how threads are created, avoiding infrequent cases where the child thread races ahead of the parent setting attributes on it.
