### PR TITLE
Fix up osx_delay(), IODelay() and IOSleep() calls

### DIFF
--- a/module/os/macos/spl/spl-kmem.c
+++ b/module/os/macos/spl/spl-kmem.c
@@ -29,6 +29,7 @@
  *
  */
 
+#include <IOKit/IOLib.h>
 #include <sys/debug.h>
 #include <sys/cdefs.h>
 #include <sys/cmn_err.h>
@@ -1005,8 +1006,8 @@ kmem_error(int error, kmem_cache_t *cparg, const void *bufarg)
 	}
 
 	if (kmem_panic > 0) {
-		extern  void IODelay(unsigned microseconds); // <IOKit/IOLib.h?
-		IODelay(1000000);
+		/* give time for the logging to register */
+		IODelay(1 * 1000 * 1000);
 		panic("kernel heap corruption detected");
 	}
 
@@ -1829,8 +1830,7 @@ kmem_depot_ws_reap(kmem_cache_t *cp)
 		mtx_contended = true;
 		printf("ZFS: SPL: %s:%s:%d: could not get lock\n",
 		    __FILE__, __func__, __LINE__);
-		extern void IOSleep(unsigned milliseconds);
-		IOSleep(1);
+		IOSleepWithLeeway(1, 1);
 		mutex_enter(&cp->cache_reap_lock);
 	}
 

--- a/module/os/macos/spl/spl-osx.c
+++ b/module/os/macos/spl/spl-osx.c
@@ -71,12 +71,7 @@ utsname(void)
 void
 osx_delay(int ticks)
 {
-	if (ticks < 2) {
-		// IODelay spins and takes microseconds as an argument
-		// don't spend more than 10msec spinning.
-		IODelay(ticks * 10000);
-		return;
-	}
+	ASSERT3S(ticks, >, 0);
 
 	// ticks are 10 msec units
 	int64_t ticks_to_go = (int64_t)ticks;
@@ -85,11 +80,52 @@ osx_delay(int ticks)
 	int64_t end_tick = start_tick + (int64_t)ticks_to_go;
 
 	do {
-		IOSleep(ticks_to_go);
+		/*
+		 * IOSleepWithLeeway takes() (milliseconds, lw_ms) where the
+		 * leeway in milliseconds lw_ms ultimately results in an
+		 * interval and deadline being given to
+		 * _clock_delay_until_deadline_with_leeway() to schedule a lax
+		 * (TIMEOUT_URGENCY_LEEWAY) wakeup and then does a
+		 * thread_block().
+		 *
+		 * Without the leeway, a strict deadline is scheduled before
+		 * the thread_block().
+		 *
+		 * Both of these options are gentle compared to a spin wait,
+		 * which will happen if the interval given to
+		 * _clock..._leeway(int, dead, lee) is less than the threshold
+		 * from ml_delay_should_spin.
+		 *
+		 * The threshold is short on ARM and is related to CPU idle
+		 * latency.  On i386 it appears to be 10 microseconds by
+		 * default, so also short compared to one tick, which is at
+		 * least ten milliseconds.
+		 *
+		 * We will always IOSleepWithLeeway a minimum amount, even if
+		 * we are invoked with delay(zero-or-negative-value);
+		 */
+
+		bool forced_sleep = false;
+
+		ASSERT3S(ticks_to_go, >, 0);
+		unsigned milliseconds_remaining = ticks_to_go * 10;
+
+		if (milliseconds_remaining < 2) {
+			milliseconds_remaining = 2;
+			forced_sleep = true;
+		}
+
+		ASSERT3U(milliseconds_remaining, <=, 1000 * 60);
+
+		IOSleepWithLeeway(milliseconds_remaining, 1);
+
+		if (forced_sleep)
+			break;
+
 		int64_t cur_tick = (int64_t)zfs_lbolt();
 		ticks_to_go = (end_tick - cur_tick);
-	} while (ticks_to_go > 0);
 
+	} while (ticks_to_go > 0);
 }
 
 

--- a/module/os/macos/zfs/zfs_file_os.c
+++ b/module/os/macos/zfs/zfs_file_os.c
@@ -19,6 +19,7 @@
  * CDDL HEADER END
  */
 
+#include <IOKit/IOLib.h>
 #include <sys/zfs_context.h>
 #include <sys/zfs_file.h>
 #include <sys/stat.h>
@@ -26,8 +27,6 @@
 #include <sys/zfs_ioctl.h>
 
 #define	FILE_FD_NOTUSED -1
-
-extern void IOSleep(unsigned milliseconds);
 
 /*
  * Open file
@@ -117,7 +116,7 @@ again:
 		 * but to static sleep until APPLE exports something for us
 		 */
 		if (local_resid == count)
-			IOSleep(1);
+			IOSleepWithLeeway(2, 1);
 
 		buf += count - local_resid;
 		*off += count - local_resid;
@@ -206,7 +205,7 @@ again:
 	if (error == EAGAIN) {
 		/* No progress at all, sleep a bit so we don't busycpu */
 		if (local_resid == count)
-			IOSleep(1);
+			IOSleepWithLeeway(2, 1);
 		buf += count - local_resid;
 		*off += count - local_resid;
 		count -= count - local_resid;


### PR DESCRIPTION
IOSleepWithLeeway() is exported to us like its counterparts IODelay and IOSleep.
The difference is between a kernel asssert_wait_deadline_with_leeway(...TIMEOUT_URGENY_LEEWAY ...) and assert_wait_deadline().   The former allows for timer coalescing and is gentler, so deploy it where it's useful, in particular in osx_delay(ticks), since a tick is 10 milliseconds long so leeway-timing won't be crucial.

The WithLeeway variant matters most when used in loops in threads which have a latency QOS set, or which are at high priority; the use in this PR can lead to a +/- 1 ms wake up time, but notieably reduces CPU under a variety of heavy loads.

xnu code decides in an architecturally-dependent way what the threshold between a spin-wait and a scheduled-wakeup-sleep-wait is, however on x86_64 and Apple Silicon it's short, not more than ten microseconds (Intel; and tunable) and possibly much less (Apple Silicon).  Almost none of our timed delays get anywhere close to the spin threshold.  The one case where a spin wait is useful (a compare-exchange loop in spl-vmem.c subject to an infrequent thundering herd which we want to gate) the loop has been softened.




