### PR TITLE
Retire Apple-deprecated MALLOC()/FREE()

### DIFF
--- a/include/os/macos/spl/IOKit/IOLib.h
+++ b/include/os/macos/spl/IOKit/IOLib.h
@@ -1,0 +1,50 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ *
+ * Copyright (C) 2023 Sean Doran <smd@use.net>
+ *
+ */
+
+#ifndef _SPL_IOLIB_H
+#define	_SPL_IOLIB_H
+
+#include <TargetConditionals.h>
+#include <AvailabilityMacros.h>
+
+#include_next <IOKit/IOLib.h>
+
+#ifndef IOMallocType
+#define	IOMallocType(T) (T *)IOMallocAligned(sizeof (T), _Alignof(T))
+/*
+ * Do a compile-time check that pointer P is of type T *.
+ * Any kind of optimization eliminates the declaration and
+ * assignment, leaving only the free itself and setting
+ * the pointer to NULL to frustrate use-after-free.
+ */
+#define	IOFreeType(P, T) do { IOFreeAligned(P, sizeof (T));		\
+		T tmp;							\
+		P = &tmp;						\
+		P = NULL; } while (0)
+#endif
+
+#endif

--- a/module/os/macos/spl/spl-ddi.c
+++ b/module/os/macos/spl/spl-ddi.c
@@ -19,6 +19,7 @@
  * CDDL HEADER END
  */
 
+#include <IOKit/IOLib.h>
 #include <sys/types.h>
 #include <sys/kmem.h>
 #include <sys/sunddi.h>
@@ -327,11 +328,12 @@ ddi_create_minor_node(dev_info_t *dip, char *name, int spec_type,
 	 * We then change "/" to "_" and create more Apple-like /dev names
 	 *
 	 */
-	MALLOC(dup, char *, strlen(name)+1, M_TEMP, M_WAITOK);
+	int len = strlen(name);
+	dup = IOMallocAligned(len + 1, _Alignof(char));
 	if (dup == NULL)
 		return (ENOMEM);
-	memcpy(dup, name, strlen(name));
-	dup[strlen(name)] = '\0';
+	memcpy(dup, name, len);
+	dup[len] = '\0';
 
 	for (r = dup;
 	    (r = strchr(r, '/'));
@@ -349,7 +351,7 @@ ddi_create_minor_node(dev_info_t *dip, char *name, int spec_type,
 		dip->devb = devfs_make_node(dev, DEVFS_BLOCK,
 		    UID_ROOT, GID_OPERATOR,
 		    0600, "disk_%s", dup);
-	FREE(dup, M_TEMP);
+	IOFreeAligned(dup, len + 1);
 
 	return (error);
 }

--- a/module/os/macos/spl/spl-kmem.c
+++ b/module/os/macos/spl/spl-kmem.c
@@ -24,7 +24,7 @@
  * Copyright (C) 2008 MacZFS
  * Copyright (C) 2013, 2020 Jorgen Lundman <lundman@lundman.net>
  * Copyright (C) 2014 Brendon Humphrey <brendon.humphrey@mac.com>
- * Copyright (C) 2017, 2021 Sean Doran <smd@use.net>
+ * Copyright (C) 2017, 2021, 2023 Sean Doran <smd@use.net>
  * Copyright 2015 Nexenta Systems, Inc.  All rights reserved.
  *
  */
@@ -4253,9 +4253,7 @@ kmem_cache_build_slablist(kmem_cache_t *cp)
 
 	for (sp = list_head(&cp->cache_complete_slabs); sp != NULL;
 	    sp = list_next(&cp->cache_complete_slabs, sp)) {
-
-		MALLOC(fs, struct free_slab *, sizeof (struct free_slab),
-		    M_TEMP, M_WAITOK);
+		fs = IOMallocType(struct free_slab);
 		fs->vmp = vmp;
 		fs->slabsize = cp->cache_slabsize;
 		fs->slab = (void *)P2ALIGN((uintptr_t)sp->slab_base,
@@ -4267,8 +4265,7 @@ kmem_cache_build_slablist(kmem_cache_t *cp)
 	for (sp = avl_first(&cp->cache_partial_slabs); sp != NULL;
 	    sp = AVL_NEXT(&cp->cache_partial_slabs, sp)) {
 
-		MALLOC(fs, struct free_slab *, sizeof (struct free_slab),
-		    M_TEMP, M_WAITOK);
+		fs = IOMallocType(struct free_slab);
 		fs->vmp = vmp;
 		fs->slabsize = cp->cache_slabsize;
 		fs->slab = (void *)P2ALIGN((uintptr_t)sp->slab_base,
@@ -4319,7 +4316,7 @@ kmem_cache_fini()
 		i++;
 		list_remove(&freelist, fs);
 		vmem_free_impl(fs->vmp, fs->slab, fs->slabsize);
-		FREE(fs, M_TEMP);
+		IOFreeType(fs, struct free_slab);
 
 	}
 	printf("SPL: Released %u slabs\n", i);

--- a/module/os/macos/spl/spl-mutex.c
+++ b/module/os/macos/spl/spl-mutex.c
@@ -23,9 +23,11 @@
  *
  * Copyright (C) 2008 MacZFS
  * Copyright (C) 2013,2020 Jorgen Lundman <lundman@lundman.net>
+ * Copyright (C) 2023 Sean Doran <smd@use.net>
  *
  */
 
+#include <IOKit/IOLib.h>
 #include <sys/mutex.h>
 #include <sys/atomic.h>
 #include <mach/mach_types.h>
@@ -198,7 +200,7 @@ spl_mutex_subsystem_fini(void)
 				// Same place
 				found++;
 				list_remove(&mutex_list, runner);
-				FREE(runner, M_TEMP);
+				IOFreeType(runner, struct leak);
 				runner = NULL;
 			} // if same
 
@@ -211,7 +213,7 @@ spl_mutex_subsystem_fini(void)
 		    leak->location_line,
 		    found);
 
-		FREE(leak, M_TEMP);
+		IOFreeType(leak, struct leak);
 		total += found;
 
 	}
@@ -273,8 +275,7 @@ spl_mutex_init(kmutex_t *mp, char *name, kmutex_type_t type, void *ibc)
 
 	struct leak *leak;
 
-	MALLOC(leak, struct leak *,
-	    sizeof (struct leak),  M_TEMP, M_WAITOK);
+	leak = IOMallocType(struct leak);
 
 	if (leak) {
 		memset(leak, 0, sizeof (struct leak));
@@ -321,7 +322,7 @@ spl_mutex_destroy(kmutex_t *mp)
 		list_remove(&mutex_list, leak);
 		mp->leak = NULL;
 		mutex_exit(&mutex_list_mutex);
-		FREE(leak, M_TEMP);
+		IOFreeType(leak, struct leak);
 	}
 #endif
 }

--- a/module/os/macos/spl/spl-rwlock.c
+++ b/module/os/macos/spl/spl-rwlock.c
@@ -23,9 +23,11 @@
  *
  * Copyright (C) 2008 MacZFS
  * Copyright (C) 2013, 2020 Jorgen Lundman <lundman@lundman.net>
+ * Copyright (C) 2023 Sean Doran <smd@use.net>
  *
  */
 
+#include <IOKit/IOLib.h>
 #include <sys/rwlock.h>
 #include <kern/debug.h>
 #include <sys/atomic.h>
@@ -111,8 +113,7 @@ rw_init(krwlock_t *rwlp, char *name, krw_type_t type, __unused void *arg)
 #ifdef SPL_DEBUG_RWLOCK
 	struct leak *leak;
 
-	MALLOC(leak, struct leak *,
-	    sizeof (struct leak),  M_TEMP, M_WAITOK);
+	leak = IOMallocType(struct leak);
 
 	if (leak) {
 		memset(leak, 0, sizeof (struct leak));
@@ -155,7 +156,7 @@ rw_destroy(krwlock_t *rwlp)
 		list_remove(&rwlock_list, leak);
 		rwlp->leak = NULL;
 		mutex_exit(&rwlock_list_mutex);
-		FREE(leak, M_TEMP);
+		IOFreeType(leak, struct leak);
 	}
 #endif
 }
@@ -364,7 +365,7 @@ spl_rwlock_fini(void)
 				// Same place
 				found++;
 				list_remove(&rwlock_list, runner);
-				FREE(runner, M_TEMP);
+				IOFreeType(runner, struct leak);
 				runner = NULL;
 			} // if same
 
@@ -377,7 +378,7 @@ spl_rwlock_fini(void)
 		    leak->location_line,
 		    found);
 
-		FREE(leak, M_TEMP);
+		IOFreeType(leak, struct leak);
 		total += found;
 
 	}

--- a/module/os/macos/spl/spl-taskq.c
+++ b/module/os/macos/spl/spl-taskq.c
@@ -29,6 +29,7 @@
 
 /*
  * Copyright (C) 2015, 2020 Jorgen Lundman <lundman@lundman.net>
+ * Copyright (C) 2023 Sean Doran <smd@use.net>
  */
 
 /*

--- a/module/os/macos/spl/spl-thread.c
+++ b/module/os/macos/spl/spl-thread.c
@@ -23,6 +23,7 @@
  *
  * Copyright (C) 2008 MacZFS
  * Copyright (C) 2013, 2020 Jorgen Lundman <lundman@lundman.net>
+ * Copyright (C) 2023 Sean Doran <smd@use.net>
  *
  */
 

--- a/module/os/macos/spl/spl-vmem.c
+++ b/module/os/macos/spl/spl-vmem.c
@@ -26,7 +26,7 @@
 /*
  * Copyright (c) 2012 by Delphix. All rights reserved.
  * Copyright (c) 2012, Joyent, Inc. All rights reserved.
- * Copyright (c) 2017, 2021 by Sean Doran <smd@use.net>
+ * Copyright (c) 2017, 2021, 2023 by Sean Doran <smd@use.net>
  */
 
 /*
@@ -458,8 +458,6 @@ extern uint64_t spl_dynamic_memory_cap_hit_floor;
 
 #define	INITIAL_BLOCK_SIZE	16ULL*1024ULL*1024ULL
 static char *initial_default_block = NULL;
-void *IOMallocAligned(vm_size_t size, vm_offset_t alignment);
-void IOFreeAligned(void * address, vm_size_t size);
 
 /*
  * Get a vmem_seg_t from the global segfree list.
@@ -3723,8 +3721,7 @@ static void vmem_fini_freelist(void *vmp, void *start, size_t size)
 {
 	struct free_slab *fs;
 
-	MALLOC(fs, struct free_slab *, sizeof (struct free_slab), M_TEMP,
-	    M_WAITOK);
+	fs = IOMallocType(struct free_slab);
 	fs->vmp = vmp;
 	fs->slabsize = size;
 	fs->slab = start;
@@ -3759,7 +3756,7 @@ vmem_free_span_list(void)
 		 * release = 1;
 		 *
 		 */
-		FREE(fs, M_TEMP);
+		IOFreeType(fs, struct free_slab);
 	}
 }
 
@@ -3969,7 +3966,7 @@ vmem_fini(vmem_t *heap)
 		list_remove(&freelist, fs);
 		// extern void segkmem_free(vmem_t *, void *, size_t);
 		// segkmem_free(fs->vmp, fs->slab, fs->slabsize);
-		FREE(fs, M_TEMP);
+		IOFreeType(fs, struct free_slab);
 	}
 	printf("SPL: WOULD HAVE released %llu bytes (%llu spans) from arenas\n",
 	    total, total_count);


### PR DESCRIPTION
Switch from MALLOC()/FREE() to IOKit/IOLib.h allocators and freers, notably IO{Malloc,Free}Type().

IOMallocType() is a useful IOKit/IOLib.h macro but not available directly to us and not available at all in older Mac OS X.  Unexpectedly, the IOMallocTypeImpl() is in recent macOS IOKit.exports, so there is potential to roll an IOMallocType() macro around that, with some effort.

Instead, for now (and because IOMallocTypeImpl() is unlikely to be in old versions we still want to support), an #ifdef transforms IOMallocTYpe() and IOFreeType() into a call to IOMallocAligned(), as using _Alignof makes xnu's job easier and is likely a small performance win, and correspondingly IOFreeAligned().

SBMALLOC/SBFREE in spl-kstat.c is a wrapper around MALLOC/FREE and does some operations on practically-arbitrary string buffers, but we can still switch to IO{Malloc,Free}Aligned, as the original allocation size is preserved.

[done] Todo 1: move the repeated #Ifdef IOMallocType into a .h file under include/os/macos.

Todo 2: can we do better than IOMallocAligned() in newer macOS?   Do we even need to?  [Update: I think this is fine for now, it gets us to a non-deprecated and long-term-stable API that we were already using elsewhere].

Done: (formerly part of Todo 2) Idea: do some compile time type matching on IOFreeType() to make sure we are freeing a pointer to that type -- static assertion would do, probably [it didn't, but it can still be a compile-time check].  I guess we let IOKit itself deal with alloc-size vs free-size mismatching.

