### PR TITLE
Report hot locks and other SPL_DEBUG_{MUTEX,RWLOCK} improvements

### DIFF
--- a/include/os/macos/spl/sys/mutex.h
+++ b/include/os/macos/spl/sys/mutex.h
@@ -114,7 +114,7 @@ typedef struct kmutex {
 #define	mutex_init(A, B, C, D) \
     spl_mutex_init(A, B, C, D, __FILE__, __FUNCTION__, __LINE__)
 void spl_mutex_init(kmutex_t *mp, char *name, kmutex_type_t type,
-    void *ibc, const char *f, const char *fn, int l);
+    void *ibc, const char *f, const char *fn, const int l);
 
 #else
 
@@ -124,24 +124,33 @@ void spl_mutex_init(kmutex_t *mp, char *name, kmutex_type_t type, void *ibc);
 #endif
 
 #ifdef SPL_DEBUG_MUTEX
-#define	mutex_enter(X) spl_mutex_enter((X), __FILE__, __LINE__)
-void spl_mutex_enter(kmutex_t *mp, const char *file, int line);
+#define	mutex_enter(X) spl_mutex_enter((X), __FILE__, __func__, __LINE__)
+void spl_mutex_enter(kmutex_t *mp, const char *file,
+    const char *func, const int line);
+void spl_dbg_mutex_destroy(kmutex_t *, const char *,
+    const char *, const int);
+#define	mutex_destroy(X) spl_dbg_mutex_destroy(X, __FILE__, __func__, __LINE__)
 #else
-#define	mutex_enter spl_mutex_enter
+#define	mutex_enter	spl_mutex_enter
 void spl_mutex_enter(kmutex_t *mp);
+#define	mutex_destroy	spl_mutex_destroy
 #endif
-
 #define	mutex_enter_nested(A, B)	mutex_enter(A)
 
-#define	mutex_destroy spl_mutex_destroy
 #define	mutex_exit spl_mutex_exit
-#define	mutex_tryenter spl_mutex_tryenter
 #define	mutex_owned spl_mutex_owned
 #define	mutex_owner spl_mutex_owner
 
 void spl_mutex_destroy(kmutex_t *mp);
 void spl_mutex_exit(kmutex_t *mp);
+#ifdef SPL_DEBUG_MUTEX
+int spl_mutex_tryenter(kmutex_t *mp,
+	const char *file, const char *func, const int line);
+#define	mutex_tryenter(M) spl_mutex_tryenter(M, __FILE__, __func__, __LINE__)
+#else
 int  spl_mutex_tryenter(kmutex_t *mp);
+#define	mutex_tryenter spl_mutex_tryenter
+#endif
 int  spl_mutex_owned(kmutex_t *mp);
 
 struct thread *spl_mutex_owner(kmutex_t *mp);

--- a/include/os/macos/spl/sys/rwlock.h
+++ b/include/os/macos/spl/sys/rwlock.h
@@ -26,6 +26,10 @@
 #ifndef _SPL_RWLOCK_H
 #define	_SPL_RWLOCK_H
 
+#ifdef DEBUG
+#define	SPL_DEBUG_RWLOCK
+#endif
+
 #include <sys/types.h>
 #include <kern/locks.h>
 
@@ -44,7 +48,7 @@ typedef enum {
 
 struct krwlock {
 	uint32_t	rw_lock[4];	/* opaque lck_rw_t data */
-	void		*rw_owner;	/* writer (exclusive) lock only */
+	kthread_t	*rw_owner;	/* writer (exclusive) lock only */
 	int		rw_readers;	/* reader lock only */
 	int		rw_pad;		/* */
 #ifdef SPL_DEBUG_RWLOCK

--- a/include/os/macos/spl/sys/sysmacros.h
+++ b/include/os/macos/spl/sys/sysmacros.h
@@ -118,9 +118,9 @@ extern unsigned int num_ecores;
  * taskqs for scrubs can be lower-priority, and are better that way for wide
  * pools (where the number of vdevs is 50% or more the number of cores).
  *
- * This value is around the level of bluetoothd or userland audio
+ * This value is just below the level of bluetoothd or userland audio
  */
-#define	dsl_scan_iss_syspri	60
+#define	DSL_SCAN_ISS_SYSPRI	59
 
 /*
  * Missing macros

--- a/module/os/macos/spl/spl-kmem.c
+++ b/module/os/macos/spl/spl-kmem.c
@@ -4263,8 +4263,8 @@ kmem_cache_build_slablist(kmem_cache_t *cp)
 	    sp = list_next(&cp->cache_complete_slabs, sp)) {
 		fs = IOMallocType(struct free_slab);
 		memset(fs, '\0', sizeof (struct free_slab));
-		strncpy(fs->vm_name, vmp->vm_name, VMEM_NAMELEN);
-		strncpy(fs->cache_name, cp->cache_name,
+		strlcpy(fs->vm_name, vmp->vm_name, VMEM_NAMELEN);
+		strlcpy(fs->cache_name, cp->cache_name,
 		    KMEM_CACHE_NAMELEN);
 		fs->vmp = vmp;
 		fs->slabsize = cp->cache_slabsize;
@@ -4279,8 +4279,8 @@ kmem_cache_build_slablist(kmem_cache_t *cp)
 
 		fs = IOMallocType(struct free_slab);
 		memset(fs, '\0', sizeof (struct free_slab));
-		strncpy(fs->vm_name, vmp->vm_name, VMEM_NAMELEN);
-		strncpy(fs->cache_name, cp->cache_name,
+		strlcpy(fs->vm_name, vmp->vm_name, VMEM_NAMELEN);
+		strlcpy(fs->cache_name, cp->cache_name,
 		    KMEM_CACHE_NAMELEN);
 		fs->vmp = vmp;
 		fs->slabsize = cp->cache_slabsize;

--- a/module/os/macos/spl/spl-mutex.c
+++ b/module/os/macos/spl/spl-mutex.c
@@ -410,13 +410,15 @@ spl_mutex_init(kmutex_t *mp, char *name, kmutex_type_t type, void *ibc)
 	leak->creation_line = line;
 	leak->mp = mp;
 
+	spl_data_barrier();
+
 	lck_mtx_lock((lck_mtx_t *)&mutex_list_mtx);
 	list_link_init(&leak->mutex_leak_node);
 	list_insert_tail(&mutex_list, leak);
 	mp->leak = leak;
 	lck_mtx_unlock((lck_mtx_t *)&mutex_list_mtx);
 #endif
-
+	spl_data_barrier();
 }
 
 void

--- a/module/os/macos/spl/spl-mutex.c
+++ b/module/os/macos/spl/spl-mutex.c
@@ -67,7 +67,7 @@ struct leak {
 	list_node_t	mutex_leak_node;
 
 #define	SPL_DEBUG_MUTEX_MAXCHAR_FUNC 24
-#define SPL_DEBUG_MUTEX_MAXCHAR_FILE 40 /* __FILE__ may have ../../... */
+#define	SPL_DEBUG_MUTEX_MAXCHAR_FILE 40 /* __FILE__ may have ../../... */
 
 	char		last_locked_file[SPL_DEBUG_MUTEX_MAXCHAR_FILE];
 	char		last_locked_function[SPL_DEBUG_MUTEX_MAXCHAR_FUNC];

--- a/module/os/macos/spl/spl-osx.c
+++ b/module/os/macos/spl/spl-osx.c
@@ -30,6 +30,7 @@
 #include <sys/systm.h>
 #include <mach/mach_types.h>
 #include <libkern/libkern.h>
+#include <sys/thread.h>
 #include <sys/mutex.h>
 #include <sys/rwlock.h>
 #include <sys/utsname.h>

--- a/module/os/macos/spl/spl-vmem.c
+++ b/module/os/macos/spl/spl-vmem.c
@@ -3968,8 +3968,15 @@ vmem_fini(vmem_t *heap)
 		// segkmem_free(fs->vmp, fs->slab, fs->slabsize);
 		IOFreeType(fs, struct free_slab);
 	}
-	printf("SPL: WOULD HAVE released %llu bytes (%llu spans) from arenas\n",
-	    total, total_count);
+	if (total != 0 && total_count != 0) {
+		printf("SPL: %s:%d: WOULD HAVE released %llu bytes"
+		    " (%llu spans) from arenas\n",
+		    __func__, __LINE__, total, total_count);
+	} else {
+		printf("SPL: %s:%d  good,"
+		    " did not have to force release any vmem spans",
+		    __func__, __LINE__);
+	}
 	list_destroy(&freelist);
 	printf("SPL: %s: Brief delay for readability...\n", __func__);
 	delay(hz);

--- a/module/os/macos/zfs/ldi_iokit.cpp
+++ b/module/os/macos/zfs/ldi_iokit.cpp
@@ -1357,15 +1357,15 @@ buf_strategy_iokit(ldi_buf_t *lbp, struct ldi_handle *lhp)
 	/* higher priority is lower numerical value */
 
 	if (lbp->b_flags & B_ASYNC) {
-		ioattr.priority++;
+		ioattr.priority += 16;
 	}
 
 	if (lbp->b_flags & B_WRITE) {
-		ioattr.priority--;
+		ioattr.priority += 16;
 	}
 
 	if (lbp->b_flags & B_THROTTLED_IO) {
-		ioattr.priority = kIOStoragePriorityBackground - 1;
+		ioattr.priority = kIOStoragePriorityBackground;
 	}
 
 	if (lbp->b_flags & B_FUA) {

--- a/module/os/macos/zfs/vdev_disk.c
+++ b/module/os/macos/zfs/vdev_disk.c
@@ -811,11 +811,52 @@ vdev_ops_t vdev_disk_ops = {
 void
 vdev_disk_init(void)
 {
-	int cpus = max_ncpus - num_ecores;
 
 	/*
-	 * keep vdev_disk_taskq_stack in-order, since we
-	 * do not know what type of ZIO it is when we use it
+	 * The "cpus" variable generates tq_nthreads, the number of threads in
+	 * each taskq, reported in
+	 * kstat.unix.taskq.vdev_disk_taskq_{name}.threads.
+	 *
+	 * Fundamentally, this can be 1.  It works for all of these queues.
+	 * For synchronous I/O that is close to what we want, as a best-effort
+	 * towards serving our callers in FIFO order.  ZFS does a good job of
+	 * ordering calls to vdev_disk_io_start().
+	 *
+	 * However, our use of IOKit is fundamentally asynchronous. Therefore
+	 * we cannot guarantee that a set of taskq jobs A, B, C get callbacks
+	 * (vdev_disk_io_done) in the same order.  Consequently we are
+	 * interested in kstat...{name}.maxtasks, which represents the
+	 * greatest observed difference between the number of tasks in the
+	 * taskq and the number of completed tasks.  With more threads, that
+	 * number drops.
+	 *
+	 * What this means is that as "cpus" is increased, IOKit is likely to
+	 * have more inflight zfs-generated IOs to queue when there is system
+	 * contention that not directly visible to our kext.  There is a
+	 * trade-off between the benefits of lower-level queue management
+	 * (which varies in intelligence) and CPU.
+	 *
+	 * With heavy IO loads this trade-off can be seen in Activity Monitor
+	 * and spindump: higher CPU (spindump exposes the cpu time of each
+	 * of these taskq threads),  and the relative smoothness of disk I/O.
+	 *
+	 * These taskq_create priorities are high compared to userland -- and
+	 * IOKit activity and other system dynamics may temporarily boost the
+	 * dispatched IO to even higher priority -- during heavy IO we risk
+	 * starving userland of CPU with many busy high-priority threads
+	 * generating CPU use in IOKit and below.
+	 *
+	 * On all systems, therefore, we cap threads below max_cpus, and on
+	 * Apple Silicon we deflate further.
+	 */
+
+	const int cpus = MAX(1, max_ncpus - num_ecores - 2);
+
+	/*
+	 * Keep vdev_disk_taskq_stack as in-order as we can, and use
+	 * defclsyspri, since this can be any type of ZIO.  This taskq
+	 * is relatively rarely used, and is mainly to track when stacks
+	 * are too large.
 	 */
 
 	vdev_disk_taskq_stack = taskq_create("vdev_disk_taskq_stack",
@@ -824,29 +865,47 @@ vdev_disk_init(void)
 
 	VERIFY(vdev_disk_taskq_stack);
 
+	/*
+	 * Slightly reduce thread priority of async write threads relative to
+	 * aysnc reads; these come in bursts as TXGs are closed out.
+	 */
+
 	vdev_disk_taskq_asyncw = taskq_create("vdev_disk_taskq_asyncw",
-	    75, defclsyspri - 4, cpus,
-	    INT_MAX, TASKQ_PREPOPULATE | TASKQ_THREADS_CPU_PCT);
+	    cpus, defclsyspri - 5, 1,
+	    INT_MAX, TASKQ_PREPOPULATE);
 
 	VERIFY(vdev_disk_taskq_asyncw);
 
 	vdev_disk_taskq_asyncr = taskq_create("vdev_disk_taskq_asyncr",
-	    75, defclsyspri - 4, cpus,
-	    INT_MAX, TASKQ_PREPOPULATE | TASKQ_THREADS_CPU_PCT);
+	    cpus, defclsyspri - 4, 1,
+	    INT_MAX, TASKQ_PREPOPULATE);
 
 	VERIFY(vdev_disk_taskq_asyncr);
 
-	int lowcpus = MAX(1, (cpus + 1) / 2);
+	/*
+	 * Reads (including prefetches) for scans ("scrubs", however these can
+	 * also be issued during resilvers) are asynchronous and
+	 * low-priority. They tend to generate the highest amount of work in
+	 * IOKit and below. There is always significant (and with some
+	 * checksums, serious) CPU activity done when the IO completes.  New
+	 * style scrubbing and resilvering do heroic efforts to sequentialize
+	 * these IOs. Therefore scrub_cpus should be the lowest number that
+	 * does not wreck scrub/resilver throughput.  Empirically this appears
+	 * to be 1.  Increasing beyond that starves userland of CPU for no
+	 * good purpose.
+	 */
+
+	const int scrub_cpus = 1;
 
 	vdev_disk_taskq_scrub = taskq_create("vdev_disk_taskq_scrub",
-	    50, dsl_scan_iss_syspri, lowcpus,
-	    INT_MAX, TASKQ_PREPOPULATE | TASKQ_THREADS_CPU_PCT);
+	    scrub_cpus, DSL_SCAN_ISS_SYSPRI, 1,
+	    INT_MAX, TASKQ_PREPOPULATE);
 
 	VERIFY(vdev_disk_taskq_scrub);
 
 	vdev_disk_taskq_default = taskq_create("vdev_disk_taskq_default",
-	    50, defclsyspri, cpus,
-	    INT_MAX, TASKQ_PREPOPULATE | TASKQ_THREADS_CPU_PCT);
+	    cpus, defclsyspri, 1,
+	    INT_MAX, TASKQ_PREPOPULATE);
 
 	VERIFY(vdev_disk_taskq_default);
 }

--- a/module/os/macos/zfs/vdev_disk.c
+++ b/module/os/macos/zfs/vdev_disk.c
@@ -43,7 +43,6 @@
  * Virtual device vector for disks.
  */
 
-
 static taskq_t *vdev_disk_taskq_asyncr;
 static taskq_t *vdev_disk_taskq_asyncw;
 static taskq_t *vdev_disk_taskq_default;
@@ -855,6 +854,7 @@ vdev_disk_init(void)
 void
 vdev_disk_fini(void)
 {
+	taskq_destroy(vdev_disk_taskq_default);
 	taskq_destroy(vdev_disk_taskq_scrub);
 	taskq_destroy(vdev_disk_taskq_asyncr);
 	taskq_destroy(vdev_disk_taskq_asyncw);

--- a/module/zfs/dsl_scan.c
+++ b/module/zfs/dsl_scan.c
@@ -3490,7 +3490,7 @@ scan_io_queues_run(dsl_scan_t *scn)
 		 */
 #if defined(__APPLE__) && defined(_KERNEL)
 		scn->scn_taskq = taskq_create("dsl_scan_iss", nthreads,
-		    dsl_scan_iss_syspri, nthreads, nthreads, TASKQ_PREPOPULATE);
+		    DSL_SCAN_ISS_SYSPRI, nthreads, nthreads, TASKQ_PREPOPULATE);
 #else
 		scn->scn_taskq = taskq_create("dsl_scan_iss", nthreads,
 		    minclsyspri, nthreads, nthreads, TASKQ_PREPOPULATE);


### PR DESCRIPTION
Also:

* destroy all the vdev_disk taskqs properly

* when getting rid of leaked slabs at kext unload, report which caches and arenas were affected

MTX/RWLOCK:

* Hardening of types and with respect to relaxed-order processors

* DEBUG builds should enable SPL_DEBUG_RWLOCK and then that should work, for example in DEBUG, rwlock cannot use mutex_{enter,exit}

* In SPL_MUTEX_DEBUG the list-watching thread will report any mutex which has been mutex_enter()ed within 10% of the highest observed enter-rate across each periodic run (~10 seconds).  Similarly report mutex_tryenter() failures to obtain the lock.

* IOMallocType() should never fail, so don't if (mp->leak) in SPL_DEBUG_MUTEX. This motivated the switch of the entire mutex watchdog thread to the
lck_mtx*/msleep/wakeup_one kernel API, which was already half-done to avoid reporting itself as a "leak".

Miscellany:

* DEBUG: do some sanity-checking at the mutex_destroy() call site, pass call-site information (file, function, line) to the wrapped spl_mutex*() functions
* Minor scrub priority changes in vdev_disk_*_taskq priority and thread count and a  related IOPriority tidying (smuggled into this PR, which already had a fix for a missing taskq_destroy that this mutex debugging caught).

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
