### PR TITLE
fix abd, have taskq_wait_synced() wait for threads to be created

### DIFF
--- a/include/os/macos/spl/sys/sysmacros.h
+++ b/include/os/macos/spl/sys/sysmacros.h
@@ -89,7 +89,7 @@ extern "C" {
 #define	is_system_labeled()		0
 
 extern unsigned int max_ncpus;
-#define	boot_ncpus max_ncpus
+extern unsigned	int boot_ncpus;
 extern unsigned int num_ecores;
 
 #ifndef RLIM64_INFINITY

--- a/include/os/macos/spl/sys/taskq.h
+++ b/include/os/macos/spl/sys/taskq.h
@@ -61,6 +61,7 @@ struct taskq_ent;
 #ifdef __APPLE__
 #define	TASKQ_TIMESHARE		0x0020  /* macOS dynamic thread priority */
 #define	TASKQ_REALLY_DYNAMIC	0x0040  /* don't filter out TASKQ_DYNAMIC */
+#define	TASKQ_CREATE_SYNCED	0x0080	/* don't deflate ncpus */
 #endif
 
 /*

--- a/module/os/macos/spl/spl-osx.c
+++ b/module/os/macos/spl/spl-osx.c
@@ -49,6 +49,7 @@
 static utsname_t utsname_static = { { 0 } };
 
 unsigned int max_ncpus = 0;
+unsigned int boot_ncpus = 0;
 unsigned int num_ecores = 0;
 uint64_t  total_memory = 0;
 uint64_t  real_total_memory = 0;
@@ -495,6 +496,9 @@ spl_start(kmod_info_t *ki, void *d)
 
 #if defined(__arm64__)
 	num_ecores = (max_ncpus > 4) ? 4 : 0;
+	boot_ncpus = MAX(1, (int)max_ncpus - (int)num_ecores);
+#else
+	boot_ncpus = max_ncpus;
 #endif
 
 	/*

--- a/module/os/macos/spl/spl-seg_kmem.c
+++ b/module/os/macos/spl/spl-seg_kmem.c
@@ -281,31 +281,27 @@ segkmem_abd_init()
 	/*
 	 * OpenZFS does not segregate the abd kmem cache out of the general
 	 * heap, leading to large numbers of short-lived slabs exchanged
-	 * between the kmem cache and it's parent.  XNU absorbs this with a
-	 * qcache, following its history of absorbing the pre-ABD zio file and
-	 * metadata caches being qcached (which raises the exchanges with the
-	 * general heap from PAGESIZE to 256k).
+	 * between the kmem cache and its parent.  XNU absorbs this with a a
+	 * large minimum request to the parent vmem_caches on large-memory
+	 * MacOS systems.
 	 */
 
 	extern vmem_t *spl_heap_arena;
 
-#define	BIG_SLAB 131072
-#ifdef __arm64__
-#define	BIG_BIG_SLAB (BIG_SLAB * 2)
-#else
-#define	BIG_BIG_SLAB BIG_SLAB
-#endif
+#define	BIG_SLAB (PAGESIZE * 16)
 
 #define	SMALL_RAM_MACHINE (4ULL * 1024ULL * 1024ULL * 1024ULL)
 
 	if (total_memory >= SMALL_RAM_MACHINE) {
 		abd_arena = vmem_create("abd_cache", NULL, 0,
-		    PAGESIZE, vmem_alloc_impl, vmem_free_impl, spl_heap_arena,
-		    BIG_BIG_SLAB, VM_SLEEP | VMC_NO_QCACHE);
+		    sizeof (void *),
+		    vmem_alloc_impl, vmem_free_impl, spl_heap_arena,
+		    BIG_SLAB, VM_SLEEP | VMC_NO_QCACHE);
 	} else {
 		abd_arena = vmem_create("abd_cache", NULL, 0,
-		    PAGESIZE, vmem_alloc_impl, vmem_free_impl, spl_heap_arena,
-		    131072, VM_SLEEP | VMC_NO_QCACHE);
+		    sizeof (void *),
+		    vmem_alloc_impl, vmem_free_impl, spl_heap_arena,
+		    PAGESIZE, VM_SLEEP | VMC_NO_QCACHE);
 	}
 
 	VERIFY3P(abd_arena, !=, NULL);
@@ -322,13 +318,15 @@ segkmem_abd_init()
 
 	if (total_memory >= SMALL_RAM_MACHINE) {
 		abd_subpage_arena = vmem_create("abd_subpage_cache", NULL, 0,
-		    sizeof (void *), vmem_alloc_impl, vmem_free_impl,
+		    sizeof (void *),
+		    vmem_alloc_impl, vmem_free_impl,
 		    spl_heap_arena,
 		    BIG_SLAB, VM_SLEEP | VMC_NO_QCACHE);
 	} else {
 		abd_subpage_arena = vmem_create("abd_subpage_cache", NULL, 0,
-		    512, vmem_alloc_impl, vmem_free_impl, abd_arena,
-		    131072, VM_SLEEP | VMC_NO_QCACHE);
+		    sizeof (void *),
+		    vmem_alloc_impl, vmem_free_impl, abd_arena,
+		    PAGESIZE, VM_SLEEP | VMC_NO_QCACHE);
 	}
 
 	VERIFY3P(abd_subpage_arena, !=, NULL);

--- a/module/os/macos/zfs/abd_os.c
+++ b/module/os/macos/zfs/abd_os.c
@@ -401,15 +401,17 @@ abd_init(void)
 	 * const int cflags = KMF_BUFTAG | KMF_LITE;
 	 * or
 	 * const int cflags = KMC_ARENA_SLAB;
+	 * (the latter tests larger exchanges of memory with the kernel)
 	 */
 
-	int cflags = KMC_ARENA_SLAB;
+	int cflags = KMF_BUFTAG | KMF_LITE;
+	// int cflags = KMC_ARENA_SLAB;
 #else
 	int cflags = KMC_NOTOUCH;
 #endif
 
 	abd_chunk_cache = kmem_cache_create("abd_chunk", zfs_abd_chunk_size,
-	    ABD_PGSIZE,
+	    sizeof (void *),
 	    NULL, NULL, NULL, NULL, abd_arena, cflags);
 
 	wmsum_init(&abd_sums.abdstat_struct_size, 0);


### PR DESCRIPTION
taskq_wait_synced() did a VERIFY() on whether the taskq's threads were the requested number, but taskq_create() can ultimately return early because taskq_thread_create() is allowed to return when two desired threads are created.

fix this race panic.  also, taskq_wait_synced() may fail if if num_ecores is nonzero (on Apple Silicon), so create a flag that lets taskq_create_common() deal with the max_ncpus.

Make boot_ncpus a variable that's MAX(1, (int)max_ncores - num_ecores). boot_ncpus is used in common code.

Modify the alignments and quanta/import sizes of the abd kmem and vmem cache creations.  Make DEBUG builds work with KMF_LITE | KMF_BUFCTL on the abd kmem caches.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
