### PR TITLE
osx_delay(): function argument type changed, adapt ASSERTs

### DIFF
--- a/module/os/macos/spl/spl-osx.c
+++ b/module/os/macos/spl/spl-osx.c
@@ -73,7 +73,7 @@ utsname(void)
 void
 osx_delay(clock_t ticks)
 {
-	ASSERT3S(ticks, >, 0);
+	ASSERT3U(ticks, <, SEC_TO_TICK(60));
 
 	// ticks are 10 msec units
 	int64_t ticks_to_go = (int64_t)ticks;
@@ -109,7 +109,7 @@ osx_delay(clock_t ticks)
 
 		bool forced_sleep = false;
 
-		ASSERT3S(ticks_to_go, >, 0);
+		ASSERT3U(ticks_to_go, <, SEC_TO_TICK(60));
 		unsigned milliseconds_remaining = ticks_to_go * 10;
 
 		if (milliseconds_remaining < 2) {


### PR DESCRIPTION
The ASSERT3S() previously looked for wraparounds as diagnostic of int underflows which would lead to an exceptionally long sleep. Now that the function takes an unsigned long type (clock_t), adapt these to to ASSERT3Us which look for long sleeps (60 seconds is unreasonably long).
