### PR TITLE
Fix a couple of Clang warnings

### DIFF
--- a/include/os/macos/spl/sys/signal.h
+++ b/include/os/macos/spl/sys/signal.h
@@ -28,18 +28,15 @@
 #ifndef _SPL_SYS_SIGNAL_H
 #define	_SPL_SYS_SIGNAL_H
 
-struct kthread;
-typedef struct kthread *kthread_t;
-
+#include <mach/mach_types.h>
+#include <sys/kernel_types.h>
 #include <sys/vm.h>
 #include_next <sys/signal.h>
 
 #define	FORREAL			0		/* Usual side-effects */
 #define	JUSTLOOKING		1		/* Don't stop the process */
 
-struct proc;
-
-extern int thread_issignal(struct proc *, kthread_t, sigset_t);
+extern int thread_issignal(proc_t, thread_t, sigset_t);
 
 #define	THREADMASK (sigmask(SIGILL)|sigmask(SIGTRAP)|\
 		sigmask(SIGIOT)|sigmask(SIGEMT)|\

--- a/include/os/macos/spl/sys/signal.h
+++ b/include/os/macos/spl/sys/signal.h
@@ -48,7 +48,7 @@ extern int thread_issignal(struct proc *, kthread_t, sigset_t);
 		sigmask(SIGPIPE)|sigmask(SIGKILL)|\
 		sigmask(SIGTERM)|sigmask(SIGINT))
 
-extern int issig();
+extern int issig(void);
 
 /* Always called with curthread */
 #define	signal_pending(p) issig()

--- a/module/os/macos/spl/spl-proc.c
+++ b/module/os/macos/spl/spl-proc.c
@@ -31,7 +31,7 @@ struct proc p0 = {0};
 
 
 int
-issig(int why)
+issig(void)
 {
 	return (thread_issignal(current_proc(), current_thread(),
 	    THREADMASK));


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR updates a couple of function declarations to fix some warnings I noticed during compilation:

```
./include/os/macos/spl/sys/signal.h:51:12: warning: a function declaration without a prototype is deprecated in all versions of C and is treated as a zero-parameter prototype in C23,
      conflicting with a subsequent definition [-Wdeprecated-non-prototype]
   51 | extern int issig();
      |            ^
module/os/macos/spl/spl-proc.c:34:1: note: conflicting prototype is here
   34 | issig(int why)
      | ^
module/os/macos/spl/spl-proc.c:36:42: warning: incompatible pointer types passing 'thread_t' (aka 'struct thread *') to parameter of type 'kthread_t' (aka 'struct kthread *')
      [-Wincompatible-pointer-types]
   36 |         return (thread_issignal(current_proc(), current_thread(),
      |                                                 ^~~~~~~~~~~~~~~~
./include/os/macos/spl/sys/signal.h:42:52: note: passing argument to parameter here
   42 | extern int thread_issignal(struct proc *, kthread_t, sigset_t);
      |                                                    ^
```

### Description
<!--- Describe your changes in detail -->

The `thread_issignal` declaration has been updated to match the original signature in XNU. The `issig` declaration and definition have been updated to declare a single void parameter.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
