### PR TITLE
icp: use correct prefix for local labels on macOS

### DIFF
--- a/include/os/freebsd/spl/sys/ia32/asm_linkage.h
+++ b/include/os/freebsd/spl/sys/ia32/asm_linkage.h
@@ -169,6 +169,10 @@ y:
 
 #define	SET_OBJ(x)
 
+/*
+ * LOCAL_LABEL defines a label which should not appear in the symbol table.
+ */
+#define LOCAL_LABEL(x) .L##x
 
 #endif /* _ASM */
 

--- a/include/os/linux/spl/sys/ia32/asm_linkage.h
+++ b/include/os/linux/spl/sys/ia32/asm_linkage.h
@@ -203,6 +203,10 @@ y:
 
 #define	SET_OBJ(x) .type	x, @object
 
+/*
+ * LOCAL_LABEL defines a label which should not appear in the symbol table.
+ */
+#define LOCAL_LABEL(x) .L##x
 
 #endif /* _ASM */
 

--- a/include/os/macos/spl/sys/ia32/asm_linkage.h
+++ b/include/os/macos/spl/sys/ia32/asm_linkage.h
@@ -176,6 +176,11 @@ y:
 
 #define	SET_OBJ(x)
 
+/*
+ * LOCAL_LABEL defines a label which should not appear in the symbol table.
+ */
+#define LOCAL_LABEL(x) L##x
+
 #endif /* _ASM */
 
 #ifdef	__cplusplus

--- a/lib/libspl/include/os/freebsd/sys/ia32/asm_linkage.h
+++ b/lib/libspl/include/os/freebsd/sys/ia32/asm_linkage.h
@@ -176,6 +176,11 @@ y:
 
 #define	SET_OBJ(x)
 
+/*
+ * LOCAL_LABEL defines a label which should not appear in the symbol table.
+ */
+#define LOCAL_LABEL(x) .L##x
+
 #endif /* _ASM */
 
 #ifdef	__cplusplus

--- a/lib/libspl/include/os/linux/sys/ia32/asm_linkage.h
+++ b/lib/libspl/include/os/linux/sys/ia32/asm_linkage.h
@@ -203,6 +203,11 @@ y:
 
 #define	SET_OBJ(x) .type	x, @object
 
+/*
+ * LOCAL_LABEL defines a label which should not appear in the symbol table.
+ */
+#define LOCAL_LABEL(x) .L##x
+
 #endif /* _ASM */
 
 #ifdef	__cplusplus

--- a/lib/libspl/include/os/macos/sys/ia32/asm_linkage.h
+++ b/lib/libspl/include/os/macos/sys/ia32/asm_linkage.h
@@ -176,6 +176,11 @@ y:
 
 #define	SET_OBJ(x)
 
+/*
+ * LOCAL_LABEL defines a label which should not appear in the symbol table.
+ */
+#define LOCAL_LABEL(x) L##x
+
 #endif /* _ASM */
 
 #ifdef	__cplusplus

--- a/module/icp/asm-x86_64/aes/aes_aesni.S
+++ b/module/icp/asm-x86_64/aes/aes_aesni.S
@@ -322,9 +322,9 @@ rijndael_key_setup_enc_intel_local:
 	FRAME_BEGIN
 	// NULL pointer sanity check
 	test	%USERCIPHERKEY, %USERCIPHERKEY
-	jz	.Lenc_key_invalid_param
+	jz	LOCAL_LABEL(enc_key_invalid_param)
 	test	%AESKEY, %AESKEY
-	jz	.Lenc_key_invalid_param
+	jz	LOCAL_LABEL(enc_key_invalid_param)
 
 	movups	(%USERCIPHERKEY), %xmm0	// user key (first 16 bytes)
 	movups	%xmm0, (%AESKEY)
@@ -332,7 +332,7 @@ rijndael_key_setup_enc_intel_local:
 	pxor	%xmm4, %xmm4		// xmm4 is assumed 0 in _key_expansion_x
 
 	cmp	$256, %KEYSIZE32
-	jnz	.Lenc_key192
+	jnz	LOCAL_LABEL(enc_key192)
 
 	// AES 256: 14 rounds in encryption key schedule
 #ifdef OPENSSL_INTERFACE
@@ -380,9 +380,9 @@ rijndael_key_setup_enc_intel_local:
 	RET
 
 .balign 4
-.Lenc_key192:
+LOCAL_LABEL(enc_key192):
 	cmp	$192, %KEYSIZE32
-	jnz	.Lenc_key128
+	jnz	LOCAL_LABEL(enc_key128)
 
 	// AES 192: 12 rounds in encryption key schedule
 #ifdef OPENSSL_INTERFACE
@@ -417,9 +417,9 @@ rijndael_key_setup_enc_intel_local:
 	RET
 
 .balign 4
-.Lenc_key128:
+LOCAL_LABEL(enc_key128):
 	cmp $128, %KEYSIZE32
-	jnz .Lenc_key_invalid_key_bits
+	jnz LOCAL_LABEL(enc_key_invalid_key_bits)
 
 	// AES 128: 10 rounds in encryption key schedule
 #ifdef OPENSSL_INTERFACE
@@ -456,7 +456,7 @@ rijndael_key_setup_enc_intel_local:
 	FRAME_END
 	RET
 
-.Lenc_key_invalid_param:
+LOCAL_LABEL(enc_key_invalid_param):
 #ifdef	OPENSSL_INTERFACE
 	mov	$-1, %rax	// user key or AES key pointer is NULL
 	FRAME_END
@@ -465,7 +465,7 @@ rijndael_key_setup_enc_intel_local:
 	/* FALLTHROUGH */
 #endif	/* OPENSSL_INTERFACE */
 
-.Lenc_key_invalid_key_bits:
+LOCAL_LABEL(enc_key_invalid_key_bits):
 #ifdef	OPENSSL_INTERFACE
 	mov	$-2, %rax	// keysize is invalid
 #else	/* Open Solaris Interface */
@@ -504,9 +504,9 @@ FRAME_BEGIN
 	call	rijndael_key_setup_enc_intel_local
 	test	%rax, %rax
 #ifdef	OPENSSL_INTERFACE
-	jnz	.Ldec_key_exit	// Failed if returned non-0
+	jnz	LOCAL_LABEL(dec_key_exit)	// Failed if returned non-0
 #else	/* OpenSolaris Interface */
-	jz	.Ldec_key_exit	// Failed if returned 0
+	jz	LOCAL_LABEL(dec_key_exit)	// Failed if returned 0
 #endif	/* OPENSSL_INTERFACE */
 
 	/*
@@ -524,7 +524,7 @@ FRAME_BEGIN
 	mov	%ROUNDS64, %ENDAESKEY
 
 .balign 4
-.Ldec_key_reorder_loop:
+LOCAL_LABEL(dec_key_reorder_loop):
 	movups	(%AESKEY), %xmm0
 	movups	(%ROUNDS64), %xmm1
 	movups	%xmm0, (%ROUNDS64)
@@ -532,10 +532,10 @@ FRAME_BEGIN
 	lea	0x10(%AESKEY), %AESKEY
 	lea	-0x10(%ROUNDS64), %ROUNDS64
 	cmp	%AESKEY, %ROUNDS64
-	ja	.Ldec_key_reorder_loop
+	ja	LOCAL_LABEL(dec_key_reorder_loop)
 
 .balign 4
-.Ldec_key_inv_loop:
+LOCAL_LABEL(dec_key_inv_loop):
 	movups	(%rcx), %xmm0
 	// Convert an encryption round key to a form usable for decryption
 	// with the "AES Inverse Mix Columns" instruction
@@ -543,9 +543,9 @@ FRAME_BEGIN
 	movups	%xmm1, (%rcx)
 	lea	0x10(%rcx), %rcx
 	cmp	%ENDAESKEY, %rcx
-	jnz	.Ldec_key_inv_loop
+	jnz	LOCAL_LABEL(dec_key_inv_loop)
 
-.Ldec_key_exit:
+LOCAL_LABEL(dec_key_exit):
 	// OpenSolaris: rax = # rounds (10, 12, or 14) or 0 for error
 	// OpenSSL: rax = 0 for OK, or non-zero for error
 	FRAME_END
@@ -612,9 +612,9 @@ ENTRY_NP(aes_encrypt_intel)
 	pxor	%KEY, %STATE			// round 0
 	lea	0x30(%KEYP), %KEYP
 	cmp	$12, %NROUNDS
-	jb	.Lenc128
+	jb	LOCAL_LABEL(enc128)
 	lea	0x20(%KEYP), %KEYP
-	je	.Lenc192
+	je	LOCAL_LABEL(enc192)
 
 	// AES 256
 	lea	0x20(%KEYP), %KEYP
@@ -624,7 +624,7 @@ ENTRY_NP(aes_encrypt_intel)
 	aesenc	%KEY, %STATE
 
 .balign 4
-.Lenc192:
+LOCAL_LABEL(enc192):
 	// AES 192 and 256
 	movups	-0x40(%KEYP), %KEY
 	aesenc	%KEY, %STATE
@@ -632,7 +632,7 @@ ENTRY_NP(aes_encrypt_intel)
 	aesenc	%KEY, %STATE
 
 .balign 4
-.Lenc128:
+LOCAL_LABEL(enc128):
 	// AES 128, 192, and 256
 	movups	-0x20(%KEYP), %KEY
 	aesenc	%KEY, %STATE
@@ -695,9 +695,9 @@ ENTRY_NP(aes_decrypt_intel)
 	pxor	%KEY, %STATE			// round 0
 	lea	0x30(%KEYP), %KEYP
 	cmp	$12, %NROUNDS
-	jb	.Ldec128
+	jb	LOCAL_LABEL(dec128)
 	lea	0x20(%KEYP), %KEYP
-	je	.Ldec192
+	je	LOCAL_LABEL(dec192)
 
 	// AES 256
 	lea	0x20(%KEYP), %KEYP
@@ -707,7 +707,7 @@ ENTRY_NP(aes_decrypt_intel)
 	aesdec	%KEY, %STATE
 
 .balign 4
-.Ldec192:
+LOCAL_LABEL(dec192):
 	// AES 192 and 256
 	movups	-0x40(%KEYP), %KEY
 	aesdec	%KEY, %STATE
@@ -715,7 +715,7 @@ ENTRY_NP(aes_decrypt_intel)
 	aesdec	%KEY, %STATE
 
 .balign 4
-.Ldec128:
+LOCAL_LABEL(dec128):
 	// AES 128, 192, and 256
 	movups	-0x20(%KEYP), %KEY
 	aesdec	%KEY, %STATE

--- a/module/icp/asm-x86_64/modes/aesni-gcm-avx2-vaes.S
+++ b/module/icp/asm-x86_64/modes/aesni-gcm-avx2-vaes.S
@@ -11,20 +11,11 @@
 /* Windows userland links with OpenSSL */
 #if !defined (_WIN32) || defined (_KERNEL)
 
-
-// There is a bug in Xcode 16.0
-#if defined(__APPLE__) && (__clang_major__ >= 16)
-#define cfi_restore set ignore,
-#define cfi_def_cfa_register set ignore,
-#define cfi_adjust_cfa_offset set ignore,
-#endif
-
-
 SECTION_STATIC
 .balign	16
 
 
-.Lbswap_mask:
+LOCAL_LABEL(bswap_mask):
 .quad	0x08090a0b0c0d0e0f, 0x0001020304050607
 
 
@@ -34,19 +25,19 @@ SECTION_STATIC
 
 
 
-.Lgfpoly:
+LOCAL_LABEL(gfpoly):
 .quad	1, 0xc200000000000000
 
 
-.Lgfpoly_and_internal_carrybit:
+LOCAL_LABEL(gfpoly_and_internal_carrybit):
 .quad	1, 0xc200000000000001
 
 .balign	32
 
-.Lctr_pattern:
+LOCAL_LABEL(ctr_pattern):
 .quad	0, 0
 .quad	1, 0
-.Linc_2blocks:
+LOCAL_LABEL(inc_2blocks):
 .quad	2, 0
 .quad	2, 0
 
@@ -62,7 +53,7 @@ ENDBR
 	vmovdqu	(%rsi),%xmm3
 	// KCF/ICP stores H in network byte order with the hi qword first
 	// so we need to swap all bytes, not the 2 qwords.
-	vmovdqu	.Lbswap_mask(%rip),%xmm4
+	vmovdqu	LOCAL_LABEL(bswap_mask)(%rip),%xmm4
 	vpshufb	%xmm4,%xmm3,%xmm3
 
 
@@ -72,10 +63,10 @@ ENDBR
 	vpshufd	$0xd3,%xmm3,%xmm0
 	vpsrad	$31,%xmm0,%xmm0
 	vpaddq	%xmm3,%xmm3,%xmm3
-	vpand	.Lgfpoly_and_internal_carrybit(%rip),%xmm0,%xmm0
+	vpand	LOCAL_LABEL(gfpoly_and_internal_carrybit)(%rip),%xmm0,%xmm0
 	vpxor	%xmm0,%xmm3,%xmm3
 
-	vbroadcasti128	.Lgfpoly(%rip),%ymm6
+	vbroadcasti128	LOCAL_LABEL(gfpoly)(%rip),%ymm6
 
 
 	vpclmulqdq	$0x00,%xmm3,%xmm3,%xmm0
@@ -172,9 +163,9 @@ ENDBR
 
 
 	vmovdqu	(%rdi),%xmm0
-	vmovdqu	.Lbswap_mask(%rip),%xmm1
+	vmovdqu	LOCAL_LABEL(bswap_mask)(%rip),%xmm1
 	vmovdqu	128-16(%rsi),%xmm2
-	vmovdqu	.Lgfpoly(%rip),%xmm3
+	vmovdqu	LOCAL_LABEL(gfpoly)(%rip),%xmm3
 	vpshufb	%xmm1,%xmm0,%xmm0
 
 	vpclmulqdq	$0x00,%xmm2,%xmm0,%xmm4
@@ -210,8 +201,8 @@ ENDBR
 
 
 
-	vmovdqu	.Lbswap_mask(%rip),%xmm6
-	vmovdqu	.Lgfpoly(%rip),%xmm7
+	vmovdqu	LOCAL_LABEL(bswap_mask)(%rip),%xmm6
+	vmovdqu	LOCAL_LABEL(gfpoly)(%rip),%xmm7
 
 
 	vmovdqu	(%rdi),%xmm5
@@ -219,7 +210,7 @@ ENDBR
 
 
 	cmpq	$32,%rcx
-	jb	.Lghash_lastblock
+	jb	LOCAL_LABEL(ghash_lastblock)
 
 
 
@@ -227,12 +218,12 @@ ENDBR
 	vinserti128	$1,%xmm7,%ymm7,%ymm7
 
 	cmpq	$127,%rcx
-	jbe	.Lghash_loop_1x
+	jbe	LOCAL_LABEL(ghash_loop_1x)
 
 
 	vmovdqu	128(%rsi),%ymm8
 	vmovdqu	128+32(%rsi),%ymm9
-.Lghash_loop_4x:
+LOCAL_LABEL(ghash_loop_4x):
 
 	vmovdqu	0(%rdx),%ymm1
 	vpshufb	%ymm6,%ymm1,%ymm1
@@ -285,7 +276,7 @@ ENDBR
 	vpxor	%ymm5,%ymm4,%ymm4
 
 
-	vbroadcasti128	.Lgfpoly(%rip),%ymm2
+	vbroadcasti128	LOCAL_LABEL(gfpoly)(%rip),%ymm2
 	vpclmulqdq	$0x01,%ymm3,%ymm2,%ymm0
 	vpshufd	$0x4e,%ymm3,%ymm3
 	vpxor	%ymm3,%ymm4,%ymm4
@@ -301,12 +292,12 @@ ENDBR
 	subq	$-128,%rdx
 	addq	$-128,%rcx
 	cmpq	$127,%rcx
-	ja	.Lghash_loop_4x
+	ja	LOCAL_LABEL(ghash_loop_4x)
 
 
 	cmpq	$32,%rcx
-	jb	.Lghash_loop_1x_done
-.Lghash_loop_1x:
+	jb	LOCAL_LABEL(ghash_loop_1x_done)
+LOCAL_LABEL(ghash_loop_1x):
 	vmovdqu	(%rdx),%ymm0
 	vpshufb	%ymm6,%ymm0,%ymm0
 	vpxor	%ymm0,%ymm5,%ymm5
@@ -330,13 +321,13 @@ ENDBR
 	addq	$32,%rdx
 	subq	$32,%rcx
 	cmpq	$32,%rcx
-	jae	.Lghash_loop_1x
-.Lghash_loop_1x_done:
+	jae	LOCAL_LABEL(ghash_loop_1x)
+LOCAL_LABEL(ghash_loop_1x_done):
 
 
-.Lghash_lastblock:
+LOCAL_LABEL(ghash_lastblock):
 	testq	%rcx,%rcx
-	jz	.Lghash_done
+	jz	LOCAL_LABEL(ghash_done)
 	vmovdqu	(%rdx),%xmm0
 	vpshufb	%xmm6,%xmm0,%xmm0
 	vpxor	%xmm0,%xmm5,%xmm5
@@ -356,7 +347,7 @@ ENDBR
 	vpxor	%xmm1,%xmm5,%xmm5
 
 
-.Lghash_done:
+LOCAL_LABEL(ghash_done):
 
 	vpshufb	%xmm6,%xmm5,%xmm5
 	vmovdqu	%xmm5,(%rdi)
@@ -380,7 +371,7 @@ ENDBR
 .hidden BORINGSSL_function_hit
 	movb	$1,BORINGSSL_function_hit+6(%rip)
 #endif
-	vbroadcasti128	.Lbswap_mask(%rip),%ymm0
+	vbroadcasti128	LOCAL_LABEL(bswap_mask)(%rip),%ymm0
 
 
 
@@ -402,19 +393,19 @@ ENDBR
 	vbroadcasti128	(%r11),%ymm10
 
 
-	vpaddd	.Lctr_pattern(%rip),%ymm11,%ymm11
+	vpaddd	LOCAL_LABEL(ctr_pattern)(%rip),%ymm11,%ymm11
 
 
 
 	cmpq	$127,%rdx
-	jbe	.Lcrypt_loop_4x_done__func1
+	jbe	LOCAL_LABEL(crypt_loop_4x_done__func1)
 
 	vmovdqu	128(%r9),%ymm7
 	vmovdqu	128+32(%r9),%ymm8
 
 
 
-	vmovdqu	.Linc_2blocks(%rip),%ymm2
+	vmovdqu	LOCAL_LABEL(inc_2blocks)(%rip),%ymm2
 	vpshufb	%ymm0,%ymm11,%ymm12
 	vpaddd	%ymm2,%ymm11,%ymm11
 	vpshufb	%ymm0,%ymm11,%ymm13
@@ -431,7 +422,7 @@ ENDBR
 	vpxor	%ymm9,%ymm15,%ymm15
 
 	leaq	16(%rcx),%rax
-.Lvaesenc_loop_first_4_vecs__func1:
+LOCAL_LABEL(vaesenc_loop_first_4_vecs__func1):
 	vbroadcasti128	(%rax),%ymm2
 	vaesenc	%ymm2,%ymm12,%ymm12
 	vaesenc	%ymm2,%ymm13,%ymm13
@@ -440,7 +431,7 @@ ENDBR
 
 	addq	$16,%rax
 	cmpq	%rax,%r11
-	jne	.Lvaesenc_loop_first_4_vecs__func1
+	jne	LOCAL_LABEL(vaesenc_loop_first_4_vecs__func1)
 	vpxor	0(%rdi),%ymm10,%ymm2
 	vpxor	32(%rdi),%ymm10,%ymm3
 	vpxor	64(%rdi),%ymm10,%ymm5
@@ -457,14 +448,14 @@ ENDBR
 	subq	$-128,%rdi
 	addq	$-128,%rdx
 	cmpq	$127,%rdx
-	jbe	.Lghash_last_ciphertext_4x__func1
+	jbe	LOCAL_LABEL(ghash_last_ciphertext_4x__func1)
 .balign	16
-.Lcrypt_loop_4x__func1:
+LOCAL_LABEL(crypt_loop_4x__func1):
 
 
 
 
-	vmovdqu	.Linc_2blocks(%rip),%ymm2
+	vmovdqu	LOCAL_LABEL(inc_2blocks)(%rip),%ymm2
 	vpshufb	%ymm0,%ymm11,%ymm12
 	vpaddd	%ymm2,%ymm11,%ymm11
 	vpshufb	%ymm0,%ymm11,%ymm13
@@ -481,8 +472,8 @@ ENDBR
 	vpxor	%ymm9,%ymm15,%ymm15
 
 	cmpl	$24,%r10d
-	jl	.Laes128__func1
-	je	.Laes192__func1
+	jl	LOCAL_LABEL(aes128__func1)
+	je	LOCAL_LABEL(aes192__func1)
 
 	vbroadcasti128	-208(%r11),%ymm2
 	vaesenc	%ymm2,%ymm12,%ymm12
@@ -496,7 +487,7 @@ ENDBR
 	vaesenc	%ymm2,%ymm14,%ymm14
 	vaesenc	%ymm2,%ymm15,%ymm15
 
-.Laes192__func1:
+LOCAL_LABEL(aes192__func1):
 	vbroadcasti128	-176(%r11),%ymm2
 	vaesenc	%ymm2,%ymm12,%ymm12
 	vaesenc	%ymm2,%ymm13,%ymm13
@@ -509,7 +500,7 @@ ENDBR
 	vaesenc	%ymm2,%ymm14,%ymm14
 	vaesenc	%ymm2,%ymm15,%ymm15
 
-.Laes128__func1:
+LOCAL_LABEL(aes128__func1):
 	prefetcht0	512(%rdi)
 	prefetcht0	512+64(%rdi)
 
@@ -613,7 +604,7 @@ ENDBR
 	vpxor	%ymm1,%ymm6,%ymm6
 
 
-	vbroadcasti128	.Lgfpoly(%rip),%ymm4
+	vbroadcasti128	LOCAL_LABEL(gfpoly)(%rip),%ymm4
 	vpclmulqdq	$0x01,%ymm5,%ymm4,%ymm2
 	vpshufd	$0x4e,%ymm5,%ymm5
 	vpxor	%ymm5,%ymm6,%ymm6
@@ -659,8 +650,8 @@ ENDBR
 
 	addq	$-128,%rdx
 	cmpq	$127,%rdx
-	ja	.Lcrypt_loop_4x__func1
-.Lghash_last_ciphertext_4x__func1:
+	ja	LOCAL_LABEL(crypt_loop_4x__func1)
+LOCAL_LABEL(ghash_last_ciphertext_4x__func1):
 
 	vmovdqu	0(%rsi),%ymm3
 	vpshufb	%ymm0,%ymm3,%ymm3
@@ -713,7 +704,7 @@ ENDBR
 	vpxor	%ymm1,%ymm6,%ymm6
 
 
-	vbroadcasti128	.Lgfpoly(%rip),%ymm4
+	vbroadcasti128	LOCAL_LABEL(gfpoly)(%rip),%ymm4
 	vpclmulqdq	$0x01,%ymm5,%ymm4,%ymm2
 	vpshufd	$0x4e,%ymm5,%ymm5
 	vpxor	%ymm5,%ymm6,%ymm6
@@ -727,10 +718,10 @@ ENDBR
 	vpxor	%xmm2,%xmm1,%xmm1
 
 	subq	$-128,%rsi
-.Lcrypt_loop_4x_done__func1:
+LOCAL_LABEL(crypt_loop_4x_done__func1):
 
 	testq	%rdx,%rdx
-	jz	.Ldone__func1
+	jz	LOCAL_LABEL(done__func1)
 
 
 
@@ -745,23 +736,23 @@ ENDBR
 	vpxor	%xmm7,%xmm7,%xmm7
 
 	cmpq	$64,%rdx
-	jb	.Llessthan64bytes__func1
+	jb	LOCAL_LABEL(lessthan64bytes__func1)
 
 
 	vpshufb	%ymm0,%ymm11,%ymm12
-	vpaddd	.Linc_2blocks(%rip),%ymm11,%ymm11
+	vpaddd	LOCAL_LABEL(inc_2blocks)(%rip),%ymm11,%ymm11
 	vpshufb	%ymm0,%ymm11,%ymm13
-	vpaddd	.Linc_2blocks(%rip),%ymm11,%ymm11
+	vpaddd	LOCAL_LABEL(inc_2blocks)(%rip),%ymm11,%ymm11
 	vpxor	%ymm9,%ymm12,%ymm12
 	vpxor	%ymm9,%ymm13,%ymm13
 	leaq	16(%rcx),%rax
-.Lvaesenc_loop_tail_1__func1:
+LOCAL_LABEL(vaesenc_loop_tail_1__func1):
 	vbroadcasti128	(%rax),%ymm2
 	vaesenc	%ymm2,%ymm12,%ymm12
 	vaesenc	%ymm2,%ymm13,%ymm13
 	addq	$16,%rax
 	cmpq	%rax,%r11
-	jne	.Lvaesenc_loop_tail_1__func1
+	jne	LOCAL_LABEL(vaesenc_loop_tail_1__func1)
 	vaesenclast	%ymm10,%ymm12,%ymm12
 	vaesenclast	%ymm10,%ymm13,%ymm13
 
@@ -797,25 +788,25 @@ ENDBR
 	addq	$64,%rdi
 	addq	$64,%rsi
 	subq	$64,%rdx
-	jz	.Lreduce__func1
+	jz	LOCAL_LABEL(reduce__func1)
 
 	vpxor	%xmm1,%xmm1,%xmm1
 
 
-.Llessthan64bytes__func1:
+LOCAL_LABEL(lessthan64bytes__func1):
 	vpshufb	%ymm0,%ymm11,%ymm12
-	vpaddd	.Linc_2blocks(%rip),%ymm11,%ymm11
+	vpaddd	LOCAL_LABEL(inc_2blocks)(%rip),%ymm11,%ymm11
 	vpshufb	%ymm0,%ymm11,%ymm13
 	vpxor	%ymm9,%ymm12,%ymm12
 	vpxor	%ymm9,%ymm13,%ymm13
 	leaq	16(%rcx),%rax
-.Lvaesenc_loop_tail_2__func1:
+LOCAL_LABEL(vaesenc_loop_tail_2__func1):
 	vbroadcasti128	(%rax),%ymm2
 	vaesenc	%ymm2,%ymm12,%ymm12
 	vaesenc	%ymm2,%ymm13,%ymm13
 	addq	$16,%rax
 	cmpq	%rax,%r11
-	jne	.Lvaesenc_loop_tail_2__func1
+	jne	LOCAL_LABEL(vaesenc_loop_tail_2__func1)
 	vaesenclast	%ymm10,%ymm12,%ymm12
 	vaesenclast	%ymm10,%ymm13,%ymm13
 
@@ -823,10 +814,10 @@ ENDBR
 
 
 	cmpq	$32,%rdx
-	jb	.Lxor_one_block__func1
-	je	.Lxor_two_blocks__func1
+	jb	LOCAL_LABEL(xor_one_block__func1)
+	je	LOCAL_LABEL(xor_two_blocks__func1)
 
-.Lxor_three_blocks__func1:
+LOCAL_LABEL(xor_three_blocks__func1):
 	vmovdqu	0(%rdi),%ymm2
 	vmovdqu	32(%rdi),%xmm3
 	vpxor	%ymm2,%ymm12,%ymm12
@@ -847,18 +838,18 @@ ENDBR
 	vpxor	%ymm4,%ymm6,%ymm6
 	vpclmulqdq	$0x11,%xmm3,%xmm13,%xmm4
 	vpxor	%ymm4,%ymm7,%ymm7
-	jmp	.Lghash_mul_one_vec_unreduced__func1
+	jmp	LOCAL_LABEL(ghash_mul_one_vec_unreduced__func1)
 
-.Lxor_two_blocks__func1:
+LOCAL_LABEL(xor_two_blocks__func1):
 	vmovdqu	(%rdi),%ymm2
 	vpxor	%ymm2,%ymm12,%ymm12
 	vmovdqu	%ymm12,(%rsi)
 	vpshufb	%ymm0,%ymm12,%ymm12
 	vpxor	%ymm1,%ymm12,%ymm12
 	vmovdqu	(%r8),%ymm2
-	jmp	.Lghash_mul_one_vec_unreduced__func1
+	jmp	LOCAL_LABEL(ghash_mul_one_vec_unreduced__func1)
 
-.Lxor_one_block__func1:
+LOCAL_LABEL(xor_one_block__func1):
 	vmovdqu	(%rdi),%xmm2
 	vpxor	%xmm2,%xmm12,%xmm12
 	vmovdqu	%xmm12,(%rsi)
@@ -866,7 +857,7 @@ ENDBR
 	vpxor	%xmm1,%xmm12,%xmm12
 	vmovdqu	(%r8),%xmm2
 
-.Lghash_mul_one_vec_unreduced__func1:
+LOCAL_LABEL(ghash_mul_one_vec_unreduced__func1):
 	vpclmulqdq	$0x00,%ymm2,%ymm12,%ymm4
 	vpxor	%ymm4,%ymm5,%ymm5
 	vpclmulqdq	$0x01,%ymm2,%ymm12,%ymm4
@@ -876,9 +867,9 @@ ENDBR
 	vpclmulqdq	$0x11,%ymm2,%ymm12,%ymm4
 	vpxor	%ymm4,%ymm7,%ymm7
 
-.Lreduce__func1:
+LOCAL_LABEL(reduce__func1):
 
-	vbroadcasti128	.Lgfpoly(%rip),%ymm2
+	vbroadcasti128	LOCAL_LABEL(gfpoly)(%rip),%ymm2
 	vpclmulqdq	$0x01,%ymm5,%ymm2,%ymm3
 	vpshufd	$0x4e,%ymm5,%ymm5
 	vpxor	%ymm5,%ymm6,%ymm6
@@ -890,7 +881,7 @@ ENDBR
 	vextracti128	$1,%ymm7,%xmm1
 	vpxor	%xmm7,%xmm1,%xmm1
 
-.Ldone__func1:
+LOCAL_LABEL(done__func1):
 
 	vpshufb	%xmm0,%xmm1,%xmm1
 	vmovdqu	%xmm1,(%r12)
@@ -912,7 +903,7 @@ ENDBR
 .cfi_offset	%r12,-16
 
 	movq	16(%rsp),%r12
-	vbroadcasti128	.Lbswap_mask(%rip),%ymm0
+	vbroadcasti128	LOCAL_LABEL(bswap_mask)(%rip),%ymm0
 
 
 
@@ -934,22 +925,22 @@ ENDBR
 	vbroadcasti128	(%r11),%ymm10
 
 
-	vpaddd	.Lctr_pattern(%rip),%ymm11,%ymm11
+	vpaddd	LOCAL_LABEL(ctr_pattern)(%rip),%ymm11,%ymm11
 
 
 
 	cmpq	$127,%rdx
-	jbe	.Lcrypt_loop_4x_done__func2
+	jbe	LOCAL_LABEL(crypt_loop_4x_done__func2)
 
 	vmovdqu	128(%r9),%ymm7
 	vmovdqu	128+32(%r9),%ymm8
 .balign	16
-.Lcrypt_loop_4x__func2:
+LOCAL_LABEL(crypt_loop_4x__func2):
 
 
 
 
-	vmovdqu	.Linc_2blocks(%rip),%ymm2
+	vmovdqu	LOCAL_LABEL(inc_2blocks)(%rip),%ymm2
 	vpshufb	%ymm0,%ymm11,%ymm12
 	vpaddd	%ymm2,%ymm11,%ymm11
 	vpshufb	%ymm0,%ymm11,%ymm13
@@ -966,8 +957,8 @@ ENDBR
 	vpxor	%ymm9,%ymm15,%ymm15
 
 	cmpl	$24,%r10d
-	jl	.Laes128__func2
-	je	.Laes192__func2
+	jl	LOCAL_LABEL(aes128__func2)
+	je	LOCAL_LABEL(aes192__func2)
 
 	vbroadcasti128	-208(%r11),%ymm2
 	vaesenc	%ymm2,%ymm12,%ymm12
@@ -981,7 +972,7 @@ ENDBR
 	vaesenc	%ymm2,%ymm14,%ymm14
 	vaesenc	%ymm2,%ymm15,%ymm15
 
-.Laes192__func2:
+LOCAL_LABEL(aes192__func2):
 	vbroadcasti128	-176(%r11),%ymm2
 	vaesenc	%ymm2,%ymm12,%ymm12
 	vaesenc	%ymm2,%ymm13,%ymm13
@@ -994,7 +985,7 @@ ENDBR
 	vaesenc	%ymm2,%ymm14,%ymm14
 	vaesenc	%ymm2,%ymm15,%ymm15
 
-.Laes128__func2:
+LOCAL_LABEL(aes128__func2):
 	prefetcht0	512(%rdi)
 	prefetcht0	512+64(%rdi)
 
@@ -1098,7 +1089,7 @@ ENDBR
 	vpxor	%ymm1,%ymm6,%ymm6
 
 
-	vbroadcasti128	.Lgfpoly(%rip),%ymm4
+	vbroadcasti128	LOCAL_LABEL(gfpoly)(%rip),%ymm4
 	vpclmulqdq	$0x01,%ymm5,%ymm4,%ymm2
 	vpshufd	$0x4e,%ymm5,%ymm5
 	vpxor	%ymm5,%ymm6,%ymm6
@@ -1144,11 +1135,11 @@ ENDBR
 	subq	$-128,%rsi
 	addq	$-128,%rdx
 	cmpq	$127,%rdx
-	ja	.Lcrypt_loop_4x__func2
-.Lcrypt_loop_4x_done__func2:
+	ja	LOCAL_LABEL(crypt_loop_4x__func2)
+LOCAL_LABEL(crypt_loop_4x_done__func2):
 
 	testq	%rdx,%rdx
-	jz	.Ldone__func2
+	jz	LOCAL_LABEL(done__func2)
 
 
 
@@ -1163,23 +1154,23 @@ ENDBR
 	vpxor	%xmm7,%xmm7,%xmm7
 
 	cmpq	$64,%rdx
-	jb	.Llessthan64bytes__func2
+	jb	LOCAL_LABEL(lessthan64bytes__func2)
 
 
 	vpshufb	%ymm0,%ymm11,%ymm12
-	vpaddd	.Linc_2blocks(%rip),%ymm11,%ymm11
+	vpaddd	LOCAL_LABEL(inc_2blocks)(%rip),%ymm11,%ymm11
 	vpshufb	%ymm0,%ymm11,%ymm13
-	vpaddd	.Linc_2blocks(%rip),%ymm11,%ymm11
+	vpaddd	LOCAL_LABEL(inc_2blocks)(%rip),%ymm11,%ymm11
 	vpxor	%ymm9,%ymm12,%ymm12
 	vpxor	%ymm9,%ymm13,%ymm13
 	leaq	16(%rcx),%rax
-.Lvaesenc_loop_tail_1__func2:
+LOCAL_LABEL(vaesenc_loop_tail_1__func2):
 	vbroadcasti128	(%rax),%ymm2
 	vaesenc	%ymm2,%ymm12,%ymm12
 	vaesenc	%ymm2,%ymm13,%ymm13
 	addq	$16,%rax
 	cmpq	%rax,%r11
-	jne	.Lvaesenc_loop_tail_1__func2
+	jne	LOCAL_LABEL(vaesenc_loop_tail_1__func2)
 	vaesenclast	%ymm10,%ymm12,%ymm12
 	vaesenclast	%ymm10,%ymm13,%ymm13
 
@@ -1215,25 +1206,25 @@ ENDBR
 	addq	$64,%rdi
 	addq	$64,%rsi
 	subq	$64,%rdx
-	jz	.Lreduce__func2
+	jz	LOCAL_LABEL(reduce__func2)
 
 	vpxor	%xmm1,%xmm1,%xmm1
 
 
-.Llessthan64bytes__func2:
+LOCAL_LABEL(lessthan64bytes__func2):
 	vpshufb	%ymm0,%ymm11,%ymm12
-	vpaddd	.Linc_2blocks(%rip),%ymm11,%ymm11
+	vpaddd	LOCAL_LABEL(inc_2blocks)(%rip),%ymm11,%ymm11
 	vpshufb	%ymm0,%ymm11,%ymm13
 	vpxor	%ymm9,%ymm12,%ymm12
 	vpxor	%ymm9,%ymm13,%ymm13
 	leaq	16(%rcx),%rax
-.Lvaesenc_loop_tail_2__func2:
+LOCAL_LABEL(vaesenc_loop_tail_2__func2):
 	vbroadcasti128	(%rax),%ymm2
 	vaesenc	%ymm2,%ymm12,%ymm12
 	vaesenc	%ymm2,%ymm13,%ymm13
 	addq	$16,%rax
 	cmpq	%rax,%r11
-	jne	.Lvaesenc_loop_tail_2__func2
+	jne	LOCAL_LABEL(vaesenc_loop_tail_2__func2)
 	vaesenclast	%ymm10,%ymm12,%ymm12
 	vaesenclast	%ymm10,%ymm13,%ymm13
 
@@ -1241,10 +1232,10 @@ ENDBR
 
 
 	cmpq	$32,%rdx
-	jb	.Lxor_one_block__func2
-	je	.Lxor_two_blocks__func2
+	jb	LOCAL_LABEL(xor_one_block__func2)
+	je	LOCAL_LABEL(xor_two_blocks__func2)
 
-.Lxor_three_blocks__func2:
+LOCAL_LABEL(xor_three_blocks__func2):
 	vmovdqu	0(%rdi),%ymm2
 	vmovdqu	32(%rdi),%xmm3
 	vpxor	%ymm2,%ymm12,%ymm12
@@ -1265,18 +1256,18 @@ ENDBR
 	vpxor	%ymm4,%ymm6,%ymm6
 	vpclmulqdq	$0x11,%xmm3,%xmm13,%xmm4
 	vpxor	%ymm4,%ymm7,%ymm7
-	jmp	.Lghash_mul_one_vec_unreduced__func2
+	jmp	LOCAL_LABEL(ghash_mul_one_vec_unreduced__func2)
 
-.Lxor_two_blocks__func2:
+LOCAL_LABEL(xor_two_blocks__func2):
 	vmovdqu	(%rdi),%ymm2
 	vpxor	%ymm2,%ymm12,%ymm12
 	vmovdqu	%ymm12,(%rsi)
 	vpshufb	%ymm0,%ymm2,%ymm12
 	vpxor	%ymm1,%ymm12,%ymm12
 	vmovdqu	(%r8),%ymm2
-	jmp	.Lghash_mul_one_vec_unreduced__func2
+	jmp	LOCAL_LABEL(ghash_mul_one_vec_unreduced__func2)
 
-.Lxor_one_block__func2:
+LOCAL_LABEL(xor_one_block__func2):
 	vmovdqu	(%rdi),%xmm2
 	vpxor	%xmm2,%xmm12,%xmm12
 	vmovdqu	%xmm12,(%rsi)
@@ -1284,7 +1275,7 @@ ENDBR
 	vpxor	%xmm1,%xmm12,%xmm12
 	vmovdqu	(%r8),%xmm2
 
-.Lghash_mul_one_vec_unreduced__func2:
+LOCAL_LABEL(ghash_mul_one_vec_unreduced__func2):
 	vpclmulqdq	$0x00,%ymm2,%ymm12,%ymm4
 	vpxor	%ymm4,%ymm5,%ymm5
 	vpclmulqdq	$0x01,%ymm2,%ymm12,%ymm4
@@ -1294,9 +1285,9 @@ ENDBR
 	vpclmulqdq	$0x11,%ymm2,%ymm12,%ymm4
 	vpxor	%ymm4,%ymm7,%ymm7
 
-.Lreduce__func2:
+LOCAL_LABEL(reduce__func2):
 
-	vbroadcasti128	.Lgfpoly(%rip),%ymm2
+	vbroadcasti128	LOCAL_LABEL(gfpoly)(%rip),%ymm2
 	vpclmulqdq	$0x01,%ymm5,%ymm2,%ymm3
 	vpshufd	$0x4e,%ymm5,%ymm5
 	vpxor	%ymm5,%ymm6,%ymm6
@@ -1308,7 +1299,7 @@ ENDBR
 	vextracti128	$1,%ymm7,%xmm1
 	vpxor	%xmm7,%xmm1,%xmm1
 
-.Ldone__func2:
+LOCAL_LABEL(done__func2):
 
 	vpshufb	%xmm0,%xmm1,%xmm1
 	vmovdqu	%xmm1,(%r12)

--- a/module/icp/asm-x86_64/modes/aesni-gcm-x86_64.S
+++ b/module/icp/asm-x86_64/modes/aesni-gcm-x86_64.S
@@ -58,13 +58,6 @@
 /* Apple needs _ */
 #if defined (__APPLE__)
 #define	gcm_avx_can_use_movbe _gcm_avx_can_use_movbe
-
-// There is a bug in Xcode 16.0
-#if defined(__APPLE__) && (__clang_major__ >= 16)
-#define cfi_restore set ignore,
-#define cfi_def_cfa_register set ignore,
-#endif
-
 #endif
 
 .extern gcm_avx_can_use_movbe
@@ -87,18 +80,18 @@ FUNCTION(_aesni_ctr32_ghash_6x)
 	vpaddb	%xmm2,%xmm13,%xmm14
 	vpxor	%xmm15,%xmm1,%xmm9
 	vmovdqu	%xmm4,16+8(%rsp)
-	jmp	.Loop6x
+	jmp	LOCAL_LABEL(oop6x)
 
 .balign	32
-.Loop6x:
+LOCAL_LABEL(oop6x):
 	addl	$100663296,%ebx
-	jc	.Lhandle_ctr32
+	jc	LOCAL_LABEL(handle_ctr32)
 	vmovdqu	0-32(%r9),%xmm3
 	vpaddb	%xmm2,%xmm14,%xmm1
 	vpxor	%xmm15,%xmm10,%xmm10
 	vpxor	%xmm15,%xmm11,%xmm11
 
-.Lresume_ctr32:
+LOCAL_LABEL(resume_ctr32):
 	vmovdqu	%xmm1,(%r8)
 	vpclmulqdq	$0x10,%xmm3,%xmm7,%xmm5
 	vpxor	%xmm15,%xmm12,%xmm12
@@ -264,7 +257,7 @@ FUNCTION(_aesni_ctr32_ghash_6x)
 	vaesenc	%xmm1,%xmm14,%xmm14
 	vmovups	160-128(%rcx),%xmm1
 	cmpl	$12,%ebp	// ICP uses 10,12,14 not 9,11,13 for rounds.
-	jb	.Lenc_tail
+	jb	LOCAL_LABEL(enc_tail)
 
 	vaesenc	%xmm15,%xmm9,%xmm9
 	vaesenc	%xmm15,%xmm10,%xmm10
@@ -282,7 +275,7 @@ FUNCTION(_aesni_ctr32_ghash_6x)
 	vaesenc	%xmm1,%xmm14,%xmm14
 	vmovups	192-128(%rcx),%xmm1
 	cmpl	$14,%ebp	// ICP does not zero key schedule.
-	jb	.Lenc_tail
+	jb	LOCAL_LABEL(enc_tail)
 
 	vaesenc	%xmm15,%xmm9,%xmm9
 	vaesenc	%xmm15,%xmm10,%xmm10
@@ -299,10 +292,10 @@ FUNCTION(_aesni_ctr32_ghash_6x)
 	vmovups	208-128(%rcx),%xmm15
 	vaesenc	%xmm1,%xmm14,%xmm14
 	vmovups	224-128(%rcx),%xmm1
-	jmp	.Lenc_tail
+	jmp	LOCAL_LABEL(enc_tail)
 
 .balign	32
-.Lhandle_ctr32:
+LOCAL_LABEL(handle_ctr32):
 	vmovdqu	(%r11),%xmm0
 	vpshufb	%xmm0,%xmm1,%xmm6
 	vmovdqu	48(%r11),%xmm5
@@ -321,10 +314,10 @@ FUNCTION(_aesni_ctr32_ghash_6x)
 	vpshufb	%xmm0,%xmm13,%xmm13
 	vpshufb	%xmm0,%xmm14,%xmm14
 	vpshufb	%xmm0,%xmm1,%xmm1
-	jmp	.Lresume_ctr32
+	jmp	LOCAL_LABEL(resume_ctr32)
 
 .balign	32
-.Lenc_tail:
+LOCAL_LABEL(enc_tail):
 	vaesenc	%xmm15,%xmm9,%xmm9
 	vmovdqu	%xmm7,16+8(%rsp)
 	vpalignr	$8,%xmm4,%xmm4,%xmm8
@@ -362,7 +355,7 @@ FUNCTION(_aesni_ctr32_ghash_6x)
 
 	addq	$0x60,%r10
 	subq	$0x6,%rdx
-	jc	.L6x_done
+	jc	LOCAL_LABEL(6x_done)
 
 	vmovups	%xmm9,-96(%rsi)
 	vpxor	%xmm15,%xmm1,%xmm9
@@ -377,9 +370,9 @@ FUNCTION(_aesni_ctr32_ghash_6x)
 	vmovups	%xmm14,-16(%rsi)
 	vmovdqa	%xmm3,%xmm14
 	vmovdqu	32+8(%rsp),%xmm7
-	jmp	.Loop6x
+	jmp	LOCAL_LABEL(oop6x)
 
-.L6x_done:
+LOCAL_LABEL(6x_done):
 	vpxor	16+8(%rsp),%xmm8,%xmm8
 	vpxor	%xmm4,%xmm8,%xmm8
 
@@ -404,18 +397,18 @@ FUNCTION(_aesni_ctr32_ghash_no_movbe_6x)
 	vpaddb	%xmm2,%xmm13,%xmm14
 	vpxor	%xmm15,%xmm1,%xmm9
 	vmovdqu	%xmm4,16+8(%rsp)
-	jmp	.Loop6x_nmb
+	jmp	LOCAL_LABEL(oop6x_nmb)
 
 .balign	32
-.Loop6x_nmb:
+LOCAL_LABEL(oop6x_nmb):
 	addl	$100663296,%ebx
-	jc	.Lhandle_ctr32_nmb
+	jc	LOCAL_LABEL(handle_ctr32_nmb)
 	vmovdqu	0-32(%r9),%xmm3
 	vpaddb	%xmm2,%xmm14,%xmm1
 	vpxor	%xmm15,%xmm10,%xmm10
 	vpxor	%xmm15,%xmm11,%xmm11
 
-.Lresume_ctr32_nmb:
+LOCAL_LABEL(resume_ctr32_nmb):
 	vmovdqu	%xmm1,(%r8)
 	vpclmulqdq	$0x10,%xmm3,%xmm7,%xmm5
 	vpxor	%xmm15,%xmm12,%xmm12
@@ -593,7 +586,7 @@ FUNCTION(_aesni_ctr32_ghash_no_movbe_6x)
 	vaesenc	%xmm1,%xmm14,%xmm14
 	vmovups	160-128(%rcx),%xmm1
 	cmpl	$12,%ebp	// ICP uses 10,12,14 not 9,11,13 for rounds.
-	jb	.Lenc_tail_nmb
+	jb	LOCAL_LABEL(enc_tail_nmb)
 
 	vaesenc	%xmm15,%xmm9,%xmm9
 	vaesenc	%xmm15,%xmm10,%xmm10
@@ -611,7 +604,7 @@ FUNCTION(_aesni_ctr32_ghash_no_movbe_6x)
 	vaesenc	%xmm1,%xmm14,%xmm14
 	vmovups	192-128(%rcx),%xmm1
 	cmpl	$14,%ebp	// ICP does not zero key schedule.
-	jb	.Lenc_tail_nmb
+	jb	LOCAL_LABEL(enc_tail_nmb)
 
 	vaesenc	%xmm15,%xmm9,%xmm9
 	vaesenc	%xmm15,%xmm10,%xmm10
@@ -628,10 +621,10 @@ FUNCTION(_aesni_ctr32_ghash_no_movbe_6x)
 	vmovups	208-128(%rcx),%xmm15
 	vaesenc	%xmm1,%xmm14,%xmm14
 	vmovups	224-128(%rcx),%xmm1
-	jmp	.Lenc_tail_nmb
+	jmp	LOCAL_LABEL(enc_tail_nmb)
 
 .balign	32
-.Lhandle_ctr32_nmb:
+LOCAL_LABEL(handle_ctr32_nmb):
 	vmovdqu	(%r11),%xmm0
 	vpshufb	%xmm0,%xmm1,%xmm6
 	vmovdqu	48(%r11),%xmm5
@@ -650,10 +643,10 @@ FUNCTION(_aesni_ctr32_ghash_no_movbe_6x)
 	vpshufb	%xmm0,%xmm13,%xmm13
 	vpshufb	%xmm0,%xmm14,%xmm14
 	vpshufb	%xmm0,%xmm1,%xmm1
-	jmp	.Lresume_ctr32_nmb
+	jmp	LOCAL_LABEL(resume_ctr32_nmb)
 
 .balign	32
-.Lenc_tail_nmb:
+LOCAL_LABEL(enc_tail_nmb):
 	vaesenc	%xmm15,%xmm9,%xmm9
 	vmovdqu	%xmm7,16+8(%rsp)
 	vpalignr	$8,%xmm4,%xmm4,%xmm8
@@ -691,7 +684,7 @@ FUNCTION(_aesni_ctr32_ghash_no_movbe_6x)
 
 	addq	$0x60,%r10
 	subq	$0x6,%rdx
-	jc	.L6x_done_nmb
+	jc	LOCAL_LABEL(6x_done_nmb)
 
 	vmovups	%xmm9,-96(%rsi)
 	vpxor	%xmm15,%xmm1,%xmm9
@@ -706,9 +699,9 @@ FUNCTION(_aesni_ctr32_ghash_no_movbe_6x)
 	vmovups	%xmm14,-16(%rsi)
 	vmovdqa	%xmm3,%xmm14
 	vmovdqu	32+8(%rsp),%xmm7
-	jmp	.Loop6x_nmb
+	jmp	LOCAL_LABEL(oop6x_nmb)
 
-.L6x_done_nmb:
+LOCAL_LABEL(6x_done_nmb):
 	vpxor	16+8(%rsp),%xmm8,%xmm8
 	vpxor	%xmm4,%xmm8,%xmm8
 
@@ -722,7 +715,7 @@ ENTRY_ALIGN(aesni_gcm_decrypt, 32)
 	ENDBR
 	xorq	%r10,%r10
 	cmpq	$0x60,%rdx
-	jb	.Lgcm_dec_abort
+	jb	LOCAL_LABEL(gcm_dec_abort)
 
 	leaq	(%rsp),%rax
 .cfi_def_cfa_register	%rax
@@ -745,7 +738,7 @@ ENTRY_ALIGN(aesni_gcm_decrypt, 32)
 	vmovdqu	(%r8),%xmm1
 	addq	$-128,%rsp
 	movl	12(%r8),%ebx
-	leaq	.Lbswap_mask(%rip),%r11
+	leaq	LOCAL_LABEL(bswap_mask)(%rip),%r11
 	leaq	-128(%rcx),%r14
 	movq	$0xf80,%r15
 	vmovdqu	(%r9),%xmm8
@@ -760,11 +753,11 @@ ENTRY_ALIGN(aesni_gcm_decrypt, 32)
 	andq	%r15,%r14
 	andq	%rsp,%r15
 	subq	%r14,%r15
-	jc	.Ldec_no_key_aliasing
+	jc	LOCAL_LABEL(dec_no_key_aliasing)
 	cmpq	$768,%r15
-	jnc	.Ldec_no_key_aliasing
+	jnc	LOCAL_LABEL(dec_no_key_aliasing)
 	subq	%r15,%rsp
-.Ldec_no_key_aliasing:
+LOCAL_LABEL(dec_no_key_aliasing):
 
 	vmovdqu	80(%rdi),%xmm7
 	leaq	(%rdi),%r14
@@ -828,7 +821,7 @@ ENTRY_ALIGN(aesni_gcm_decrypt, 32)
 .cfi_restore	%rbx
 	leaq	(%rax),%rsp
 .cfi_def_cfa_register	%rsp
-.Lgcm_dec_abort:
+LOCAL_LABEL(gcm_dec_abort):
 	movq	%r10,%rax
 	RET
 .cfi_endproc
@@ -846,7 +839,7 @@ FUNCTION(_aesni_ctr32_6x)
 	leaq	32-128(%rcx),%r12
 	vpxor	%xmm4,%xmm1,%xmm9
 	addl	$100663296,%ebx
-	jc	.Lhandle_ctr32_2
+	jc	LOCAL_LABEL(handle_ctr32_2)
 	vpaddb	%xmm2,%xmm1,%xmm10
 	vpaddb	%xmm2,%xmm10,%xmm11
 	vpxor	%xmm4,%xmm10,%xmm10
@@ -858,10 +851,10 @@ FUNCTION(_aesni_ctr32_6x)
 	vpxor	%xmm4,%xmm13,%xmm13
 	vpaddb	%xmm2,%xmm14,%xmm1
 	vpxor	%xmm4,%xmm14,%xmm14
-	jmp	.Loop_ctr32
+	jmp	LOCAL_LABEL(oop_ctr32)
 
 .balign	16
-.Loop_ctr32:
+LOCAL_LABEL(oop_ctr32):
 	vaesenc	%xmm15,%xmm9,%xmm9
 	vaesenc	%xmm15,%xmm10,%xmm10
 	vaesenc	%xmm15,%xmm11,%xmm11
@@ -871,7 +864,7 @@ FUNCTION(_aesni_ctr32_6x)
 	vmovups	(%r12),%xmm15
 	leaq	16(%r12),%r12
 	decl	%r13d
-	jnz	.Loop_ctr32
+	jnz	LOCAL_LABEL(oop_ctr32)
 
 	vmovdqu	(%r12),%xmm3
 	vaesenc	%xmm15,%xmm9,%xmm9
@@ -904,7 +897,7 @@ FUNCTION(_aesni_ctr32_6x)
 
 	RET
 .balign	32
-.Lhandle_ctr32_2:
+LOCAL_LABEL(handle_ctr32_2):
 	vpshufb	%xmm0,%xmm1,%xmm6
 	vmovdqu	48(%r11),%xmm5
 	vpaddd	64(%r11),%xmm6,%xmm10
@@ -924,7 +917,7 @@ FUNCTION(_aesni_ctr32_6x)
 	vpxor	%xmm4,%xmm13,%xmm13
 	vpshufb	%xmm0,%xmm1,%xmm1
 	vpxor	%xmm4,%xmm14,%xmm14
-	jmp	.Loop_ctr32
+	jmp	LOCAL_LABEL(oop_ctr32)
 .cfi_endproc
 SET_SIZE(_aesni_ctr32_6x)
 
@@ -933,7 +926,7 @@ ENTRY_ALIGN(aesni_gcm_encrypt, 32)
 	ENDBR
 	xorq	%r10,%r10
 	cmpq	$288,%rdx
-	jb	.Lgcm_enc_abort
+	jb	LOCAL_LABEL(gcm_enc_abort)
 
 	leaq	(%rsp),%rax
 .cfi_def_cfa_register	%rax
@@ -956,7 +949,7 @@ ENTRY_ALIGN(aesni_gcm_encrypt, 32)
 	vmovdqu	(%r8),%xmm1
 	addq	$-128,%rsp
 	movl	12(%r8),%ebx
-	leaq	.Lbswap_mask(%rip),%r11
+	leaq	LOCAL_LABEL(bswap_mask)(%rip),%r11
 	leaq	-128(%rcx),%r14
 	movq	$0xf80,%r15
 	leaq	128(%rcx),%rcx
@@ -967,11 +960,11 @@ ENTRY_ALIGN(aesni_gcm_encrypt, 32)
 	andq	%r15,%r14
 	andq	%rsp,%r15
 	subq	%r14,%r15
-	jc	.Lenc_no_key_aliasing
+	jc	LOCAL_LABEL(enc_no_key_aliasing)
 	cmpq	$768,%r15
-	jnc	.Lenc_no_key_aliasing
+	jnc	LOCAL_LABEL(enc_no_key_aliasing)
 	subq	%r15,%rsp
-.Lenc_no_key_aliasing:
+LOCAL_LABEL(enc_no_key_aliasing):
 
 	leaq	(%rsi),%r14
 	leaq	-192(%rsi,%rdx,1),%r15
@@ -1204,7 +1197,7 @@ ENTRY_ALIGN(aesni_gcm_encrypt, 32)
 .cfi_restore	%rbx
 	leaq	(%rax),%rsp
 .cfi_def_cfa_register	%rsp
-.Lgcm_enc_abort:
+LOCAL_LABEL(gcm_enc_abort):
 	movq	%r10,%rax
 	RET
 .cfi_endproc
@@ -1256,15 +1249,15 @@ SET_SIZE(atomic_toggle_boolean_nv)
 SECTION_STATIC
 
 .balign	64
-.Lbswap_mask:
+LOCAL_LABEL(bswap_mask):
 .byte	15,14,13,12,11,10,9,8,7,6,5,4,3,2,1,0
-.Lpoly:
+LOCAL_LABEL(poly):
 .byte	0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0xc2
-.Lone_msb:
+LOCAL_LABEL(one_msb):
 .byte	0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1
-.Ltwo_lsb:
+LOCAL_LABEL(two_lsb):
 .byte	2,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
-.Lone_lsb:
+LOCAL_LABEL(one_lsb):
 .byte	1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
 .byte	65,69,83,45,78,73,32,71,67,77,32,109,111,100,117,108,101,32,102,111,114,32,120,56,54,95,54,52,44,32,67,82,89,80,84,79,71,65,77,83,32,98,121,32,60,97,112,112,114,111,64,111,112,101,110,115,115,108,46,111,114,103,62,0
 .balign	64

--- a/module/icp/asm-x86_64/modes/gcm_pclmulqdq.S
+++ b/module/icp/asm-x86_64/modes/gcm_pclmulqdq.S
@@ -6,13 +6,13 @@
  * Common Development and Distribution License (the "License").
  * You may not use this file except in compliance with the License.
  *
- * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * You can obtain a copy of the license at usr/src/OPENSOLARISLOCAL_LABEL(ICENSE)
  * or https://opensource.org/licenses/CDDL-1.0.
  * See the License for the specific language governing permissions
  * and limitations under the License.
  *
  * When distributing Covered Code, include this CDDL HEADER in each
- * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * file and include the License file at usr/src/OPENSOLARISLOCAL_LABEL(ICENSE).
  * If applicable, add the following below this CDDL HEADER, with the
  * fields enclosed by brackets "[]" replaced with your own identifying
  * information: Portions Copyright [yyyy] [name of copyright owner]
@@ -104,7 +104,7 @@ gcm_mul_pclmulqdq(uint64_t *x_in, uint64_t *y, uint64_t *res) {
 //	 15, 14, 13, 12, 11, 10, 9, 8, 7, 6 ,5, 4, 3, 2, 1, 0 };
 SECTION_STATIC
 .balign XMM_ALIGN
-.Lbyte_swap16_mask:
+LOCAL_LABEL(byte_swap16_mask):
 	.byte	15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0
 
 
@@ -150,7 +150,7 @@ ENTRY_NP(gcm_mul_pclmulqdq)
 	//
 	// Byte swap 16-byte input
 	//
-	lea	.Lbyte_swap16_mask(%rip), %rax
+	lea	LOCAL_LABEL(byte_swap16_mask)(%rip), %rax
 	movups	(%rax), %xmm10
 	pshufb	%xmm10, %xmm0
 	pshufb	%xmm10, %xmm1

--- a/module/icp/asm-x86_64/modes/ghash-x86_64.S
+++ b/module/icp/asm-x86_64/modes/ghash-x86_64.S
@@ -110,9 +110,9 @@ ENTRY_ALIGN(gcm_gmult_clmul, 16)
 .cfi_startproc
 	ENDBR
 
-.L_gmult_clmul:
+LOCAL_LABEL(_gmult_clmul):
 	movdqu	(%rdi),%xmm0
-	movdqa	.Lbswap_mask(%rip),%xmm5
+	movdqa	LOCAL_LABEL(bswap_mask)(%rip),%xmm5
 	movdqu	(%rsi),%xmm2
 	movdqu	32(%rsi),%xmm4
 .byte	102,15,56,0,197
@@ -168,7 +168,7 @@ ENTRY_ALIGN(gcm_init_htab_avx, 32)
 	vmovdqu	(%rsi),%xmm2
 	// KCF/ICP stores H in network byte order with the hi qword first
 	// so we need to swap all bytes, not the 2 qwords.
-	vmovdqu	.Lbswap_mask(%rip),%xmm4
+	vmovdqu	LOCAL_LABEL(bswap_mask)(%rip),%xmm4
 	vpshufb	%xmm4,%xmm2,%xmm2
 
 
@@ -181,16 +181,16 @@ ENTRY_ALIGN(gcm_init_htab_avx, 32)
 	vpor	%xmm3,%xmm2,%xmm2
 
 
-	vpand	.L0x1c2_polynomial(%rip),%xmm5,%xmm5
+	vpand	LOCAL_LABEL(0x1c2_polynomial)(%rip),%xmm5,%xmm5
 	vpxor	%xmm5,%xmm2,%xmm2
 
 	vpunpckhqdq	%xmm2,%xmm2,%xmm6
 	vmovdqa	%xmm2,%xmm0
 	vpxor	%xmm2,%xmm6,%xmm6
 	movq	$4,%r10
-	jmp	.Linit_start_avx
+	jmp	LOCAL_LABEL(init_start_avx)
 .balign	32
-.Linit_loop_avx:
+LOCAL_LABEL(init_loop_avx):
 	vpalignr	$8,%xmm3,%xmm4,%xmm5
 	vmovdqu	%xmm5,-16(%rdi)
 	vpunpckhqdq	%xmm0,%xmm0,%xmm3
@@ -222,7 +222,7 @@ ENTRY_ALIGN(gcm_init_htab_avx, 32)
 	vpxor	%xmm4,%xmm0,%xmm0
 	vpsrlq	$1,%xmm0,%xmm0
 	vpxor	%xmm1,%xmm0,%xmm0
-.Linit_start_avx:
+LOCAL_LABEL(init_start_avx):
 	vmovdqa	%xmm0,%xmm5
 	vpunpckhqdq	%xmm0,%xmm0,%xmm3
 	vpxor	%xmm0,%xmm3,%xmm3
@@ -261,7 +261,7 @@ ENTRY_ALIGN(gcm_init_htab_avx, 32)
 	vmovdqu	%xmm0,16(%rdi)
 	leaq	48(%rdi),%rdi
 	subq	$1,%r10
-	jnz	.Linit_loop_avx
+	jnz	LOCAL_LABEL(init_loop_avx)
 
 	vpalignr	$8,%xmm4,%xmm3,%xmm5
 	vmovdqu	%xmm5,-16(%rdi)
@@ -275,7 +275,7 @@ SET_SIZE(gcm_init_htab_avx)
 ENTRY_ALIGN(gcm_gmult_avx, 32)
 .cfi_startproc
 	ENDBR
-	jmp	.L_gmult_clmul
+	jmp	LOCAL_LABEL(_gmult_clmul)
 .cfi_endproc
 SET_SIZE(gcm_gmult_avx)
 
@@ -285,12 +285,12 @@ ENTRY_ALIGN(gcm_ghash_avx, 32)
 	vzeroupper
 
 	vmovdqu	(%rdi),%xmm10
-	leaq	.L0x1c2_polynomial(%rip),%r10
+	leaq	LOCAL_LABEL(0x1c2_polynomial)(%rip),%r10
 	leaq	64(%rsi),%rsi
-	vmovdqu	.Lbswap_mask(%rip),%xmm13
+	vmovdqu	LOCAL_LABEL(bswap_mask)(%rip),%xmm13
 	vpshufb	%xmm13,%xmm10,%xmm10
 	cmpq	$0x80,%rcx
-	jb	.Lshort_avx
+	jb	LOCAL_LABEL(short_avx)
 	subq	$0x80,%rcx
 
 	vmovdqu	112(%rdx),%xmm14
@@ -381,14 +381,14 @@ ENTRY_ALIGN(gcm_ghash_avx, 32)
 
 	leaq	128(%rdx),%rdx
 	cmpq	$0x80,%rcx
-	jb	.Ltail_avx
+	jb	LOCAL_LABEL(tail_avx)
 
 	vpxor	%xmm10,%xmm15,%xmm15
 	subq	$0x80,%rcx
-	jmp	.Loop8x_avx
+	jmp	LOCAL_LABEL(oop8x_avx)
 
 .balign	32
-.Loop8x_avx:
+LOCAL_LABEL(oop8x_avx):
 	vpunpckhqdq	%xmm15,%xmm15,%xmm8
 	vmovdqu	112(%rdx),%xmm14
 	vpxor	%xmm0,%xmm3,%xmm3
@@ -502,13 +502,13 @@ ENTRY_ALIGN(gcm_ghash_avx, 32)
 
 	leaq	128(%rdx),%rdx
 	subq	$0x80,%rcx
-	jnc	.Loop8x_avx
+	jnc	LOCAL_LABEL(oop8x_avx)
 
 	addq	$0x80,%rcx
-	jmp	.Ltail_no_xor_avx
+	jmp	LOCAL_LABEL(tail_no_xor_avx)
 
 .balign	32
-.Lshort_avx:
+LOCAL_LABEL(short_avx):
 	vmovdqu	-16(%rdx,%rcx,1),%xmm14
 	leaq	(%rdx,%rcx,1),%rdx
 	vmovdqu	0-64(%rsi),%xmm6
@@ -519,7 +519,7 @@ ENTRY_ALIGN(gcm_ghash_avx, 32)
 	vmovdqa	%xmm1,%xmm4
 	vmovdqa	%xmm2,%xmm5
 	subq	$0x10,%rcx
-	jz	.Ltail_avx
+	jz	LOCAL_LABEL(tail_avx)
 
 	vpunpckhqdq	%xmm15,%xmm15,%xmm8
 	vpxor	%xmm0,%xmm3,%xmm3
@@ -534,7 +534,7 @@ ENTRY_ALIGN(gcm_ghash_avx, 32)
 	vpclmulqdq	$0x00,%xmm7,%xmm8,%xmm2
 	vpsrldq	$8,%xmm7,%xmm7
 	subq	$0x10,%rcx
-	jz	.Ltail_avx
+	jz	LOCAL_LABEL(tail_avx)
 
 	vpunpckhqdq	%xmm15,%xmm15,%xmm8
 	vpxor	%xmm0,%xmm3,%xmm3
@@ -549,7 +549,7 @@ ENTRY_ALIGN(gcm_ghash_avx, 32)
 	vpclmulqdq	$0x00,%xmm7,%xmm8,%xmm2
 	vmovdqu	80-64(%rsi),%xmm7
 	subq	$0x10,%rcx
-	jz	.Ltail_avx
+	jz	LOCAL_LABEL(tail_avx)
 
 	vpunpckhqdq	%xmm15,%xmm15,%xmm8
 	vpxor	%xmm0,%xmm3,%xmm3
@@ -564,7 +564,7 @@ ENTRY_ALIGN(gcm_ghash_avx, 32)
 	vpclmulqdq	$0x00,%xmm7,%xmm8,%xmm2
 	vpsrldq	$8,%xmm7,%xmm7
 	subq	$0x10,%rcx
-	jz	.Ltail_avx
+	jz	LOCAL_LABEL(tail_avx)
 
 	vpunpckhqdq	%xmm15,%xmm15,%xmm8
 	vpxor	%xmm0,%xmm3,%xmm3
@@ -579,7 +579,7 @@ ENTRY_ALIGN(gcm_ghash_avx, 32)
 	vpclmulqdq	$0x00,%xmm7,%xmm8,%xmm2
 	vmovdqu	128-64(%rsi),%xmm7
 	subq	$0x10,%rcx
-	jz	.Ltail_avx
+	jz	LOCAL_LABEL(tail_avx)
 
 	vpunpckhqdq	%xmm15,%xmm15,%xmm8
 	vpxor	%xmm0,%xmm3,%xmm3
@@ -594,7 +594,7 @@ ENTRY_ALIGN(gcm_ghash_avx, 32)
 	vpclmulqdq	$0x00,%xmm7,%xmm8,%xmm2
 	vpsrldq	$8,%xmm7,%xmm7
 	subq	$0x10,%rcx
-	jz	.Ltail_avx
+	jz	LOCAL_LABEL(tail_avx)
 
 	vpunpckhqdq	%xmm15,%xmm15,%xmm8
 	vpxor	%xmm0,%xmm3,%xmm3
@@ -609,12 +609,12 @@ ENTRY_ALIGN(gcm_ghash_avx, 32)
 	vpclmulqdq	$0x00,%xmm7,%xmm8,%xmm2
 	vmovq	184-64(%rsi),%xmm7
 	subq	$0x10,%rcx
-	jmp	.Ltail_avx
+	jmp	LOCAL_LABEL(tail_avx)
 
 .balign	32
-.Ltail_avx:
+LOCAL_LABEL(tail_avx):
 	vpxor	%xmm10,%xmm15,%xmm15
-.Ltail_no_xor_avx:
+LOCAL_LABEL(tail_no_xor_avx):
 	vpunpckhqdq	%xmm15,%xmm15,%xmm8
 	vpxor	%xmm0,%xmm3,%xmm3
 	vpclmulqdq	$0x00,%xmm6,%xmm15,%xmm0
@@ -647,7 +647,7 @@ ENTRY_ALIGN(gcm_ghash_avx, 32)
 	vpxor	%xmm9,%xmm10,%xmm10
 
 	cmpq	$0,%rcx
-	jne	.Lshort_avx
+	jne	LOCAL_LABEL(short_avx)
 
 	vpshufb	%xmm13,%xmm10,%xmm10
 	vmovdqu	%xmm10,(%rdi)
@@ -660,23 +660,23 @@ SET_SIZE(gcm_ghash_avx)
 
 SECTION_STATIC
 .balign	64
-.Lbswap_mask:
+LOCAL_LABEL(bswap_mask):
 .byte	15,14,13,12,11,10,9,8,7,6,5,4,3,2,1,0
-.L0x1c2_polynomial:
+LOCAL_LABEL(0x1c2_polynomial):
 .byte	1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0xc2
-.L7_mask:
+LOCAL_LABEL(7_mask):
 .long	7,0,7,0
-.L7_mask_poly:
+LOCAL_LABEL(7_mask_poly):
 .long	7,0,450,0
 .balign	64
-SET_OBJ(.Lrem_4bit)
-.Lrem_4bit:
+SET_OBJ(LOCAL_LABEL(rem_4bit))
+LOCAL_LABEL(rem_4bit):
 .long	0,0,0,471859200,0,943718400,0,610271232
 .long	0,1887436800,0,1822425088,0,1220542464,0,1423966208
 .long	0,3774873600,0,4246732800,0,3644850176,0,3311403008
 .long	0,2441084928,0,2376073216,0,2847932416,0,3051356160
-SET_OBJ(.Lrem_8bit)
-.Lrem_8bit:
+SET_OBJ(LOCAL_LABEL(rem_8bit))
+LOCAL_LABEL(rem_8bit):
 .value	0x0000,0x01C2,0x0384,0x0246,0x0708,0x06CA,0x048C,0x054E
 .value	0x0E10,0x0FD2,0x0D94,0x0C56,0x0918,0x08DA,0x0A9C,0x0B5E
 .value	0x1C20,0x1DE2,0x1FA4,0x1E66,0x1B28,0x1AEA,0x18AC,0x196E

--- a/module/icp/asm-x86_64/sha2/sha256-x86_64.S
+++ b/module/icp/asm-x86_64/sha2/sha256-x86_64.S
@@ -26,15 +26,6 @@
 #include <sys/asm_linkage.h>
 #include <sys/frame.h>
 
-#if defined(__APPLE__) && (__clang_major__ >= 16)
-// There is a bug in Xcode 16.0
-// let sadd #if version == here?
-#define cfi_restore set ignore,
-#define cfi_def_cfa_register set ignore,
-#define cfi_def_cfa set ignore,nothing #
-#define cfi_escape set ignore,nothing #
-#endif
-
 SECTION_STATIC
 
 .balign	64
@@ -106,7 +97,7 @@ ENTRY_ALIGN(zfs_sha256_transform_x64, 16)
 	movq	%rdx,64+16(%rsp)
 	movq	%rax,88(%rsp)
 .cfi_escape	0x0f,0x06,0x77,0xd8,0x00,0x06,0x23,0x08
-.Lprologue:
+LOCAL_LABEL(prologue):
 	movl	0(%rdi),%eax
 	movl	4(%rdi),%ebx
 	movl	8(%rdi),%ecx
@@ -115,9 +106,9 @@ ENTRY_ALIGN(zfs_sha256_transform_x64, 16)
 	movl	20(%rdi),%r9d
 	movl	24(%rdi),%r10d
 	movl	28(%rdi),%r11d
-	jmp	.Lloop
+	jmp	LOCAL_LABEL(loop)
 .balign	16
-.Lloop:
+LOCAL_LABEL(loop):
 	movl	%ebx,%edi
 	leaq	K256(%rip),%rbp
 	xorl	%ecx,%edi
@@ -632,9 +623,9 @@ ENTRY_ALIGN(zfs_sha256_transform_x64, 16)
 	addl	%r12d,%r8d
 	addl	%r12d,%eax
 	leaq	20(%rbp),%rbp
-	jmp	.Lrounds_16_xx
+	jmp	LOCAL_LABEL(rounds_16_xx)
 .balign	16
-.Lrounds_16_xx:
+LOCAL_LABEL(rounds_16_xx):
 	movl	4(%rsp),%r13d
 	movl	56(%rsp),%r15d
 	movl	%r13d,%r12d
@@ -1388,7 +1379,7 @@ ENTRY_ALIGN(zfs_sha256_transform_x64, 16)
 	addl	%r12d,%eax
 	leaq	20(%rbp),%rbp
 	cmpb	$0,3(%rbp)
-	jnz	.Lrounds_16_xx
+	jnz	LOCAL_LABEL(rounds_16_xx)
 	movq	64+0(%rsp),%rdi
 	addl	%r14d,%eax
 	leaq	64(%rsi),%rsi
@@ -1409,7 +1400,7 @@ ENTRY_ALIGN(zfs_sha256_transform_x64, 16)
 	movl	%r9d,20(%rdi)
 	movl	%r10d,24(%rdi)
 	movl	%r11d,28(%rdi)
-	jb	.Lloop
+	jb	LOCAL_LABEL(loop)
 	movq	88(%rsp),%rsi
 .cfi_def_cfa	%rsi,8
 	movq	-48(%rsi),%r15
@@ -1426,7 +1417,7 @@ ENTRY_ALIGN(zfs_sha256_transform_x64, 16)
 .cfi_restore	%rbx
 	leaq	(%rsi),%rsp
 .cfi_def_cfa_register	%rsp
-.Lepilogue:
+LOCAL_LABEL(epilogue):
 	RET
 .cfi_endproc
 SET_SIZE(zfs_sha256_transform_x64)
@@ -1446,10 +1437,10 @@ ENTRY_ALIGN(zfs_sha256_transform_shani, 64)
 	movdqa	%xmm7,%xmm8
 .byte	102,15,58,15,202,8
 	punpcklqdq	%xmm0,%xmm2
-	jmp	.Loop_shani
+	jmp	LOCAL_LABEL(oop_shani)
 
 .balign	16
-.Loop_shani:
+LOCAL_LABEL(oop_shani):
 	movdqu	(%rsi),%xmm3
 	movdqu	16(%rsi),%xmm4
 	movdqu	32(%rsi),%xmm5
@@ -1626,7 +1617,7 @@ ENTRY_ALIGN(zfs_sha256_transform_shani, 64)
 
 	paddd	%xmm10,%xmm2
 	paddd	%xmm9,%xmm1
-	jnz	.Loop_shani
+	jnz	LOCAL_LABEL(oop_shani)
 
 	pshufd	$0xb1,%xmm2,%xmm2
 	pshufd	$0x1b,%xmm1,%xmm7
@@ -1667,7 +1658,7 @@ ENTRY_ALIGN(zfs_sha256_transform_ssse3, 64)
 	movq	%rdx,64+16(%rsp)
 	movq	%rax,88(%rsp)
 .cfi_escape	0x0f,0x06,0x77,0xd8,0x00,0x06,0x23,0x08
-.Lprologue_ssse3:
+LOCAL_LABEL(prologue_ssse3):
 
 	movl	0(%rdi),%eax
 	movl	4(%rdi),%ebx
@@ -1678,9 +1669,9 @@ ENTRY_ALIGN(zfs_sha256_transform_ssse3, 64)
 	movl	24(%rdi),%r10d
 	movl	28(%rdi),%r11d
 
-	jmp	.Lloop_ssse3
+	jmp	LOCAL_LABEL(loop_ssse3)
 .balign	16
-.Lloop_ssse3:
+LOCAL_LABEL(loop_ssse3):
 	movdqa	K256+512(%rip),%xmm7
 	movdqu	0(%rsi),%xmm0
 	movdqu	16(%rsi),%xmm1
@@ -1707,10 +1698,10 @@ ENTRY_ALIGN(zfs_sha256_transform_ssse3, 64)
 	xorl	%ecx,%edi
 	movdqa	%xmm7,48(%rsp)
 	movl	%r8d,%r13d
-	jmp	.Lssse3_00_47
+	jmp	LOCAL_LABEL(ssse3_00_47)
 
 .balign	16
-.Lssse3_00_47:
+LOCAL_LABEL(ssse3_00_47):
 	subq	$-128,%rbp
 	rorl	$14,%r13d
 	movdqa	%xmm1,%xmm4
@@ -2289,7 +2280,7 @@ ENTRY_ALIGN(zfs_sha256_transform_ssse3, 64)
 	addl	%eax,%r14d
 	movdqa	%xmm6,48(%rsp)
 	cmpb	$0,131(%rbp)
-	jne	.Lssse3_00_47
+	jne	LOCAL_LABEL(ssse3_00_47)
 	rorl	$14,%r13d
 	movl	%r14d,%eax
 	movl	%r9d,%r12d
@@ -2729,7 +2720,7 @@ ENTRY_ALIGN(zfs_sha256_transform_ssse3, 64)
 	movl	%r9d,20(%rdi)
 	movl	%r10d,24(%rdi)
 	movl	%r11d,28(%rdi)
-	jb	.Lloop_ssse3
+	jb	LOCAL_LABEL(loop_ssse3)
 
 	movq	88(%rsp),%rsi
 .cfi_def_cfa	%rsi,8
@@ -2747,7 +2738,7 @@ ENTRY_ALIGN(zfs_sha256_transform_ssse3, 64)
 .cfi_restore	%rbx
 	leaq	(%rsi),%rsp
 .cfi_def_cfa_register	%rsp
-.Lepilogue_ssse3:
+LOCAL_LABEL(epilogue_ssse3):
 	RET
 .cfi_endproc
 SET_SIZE(zfs_sha256_transform_ssse3)
@@ -2779,7 +2770,7 @@ ENTRY_ALIGN(zfs_sha256_transform_avx, 64)
 	movq	%rdx,64+16(%rsp)
 	movq	%rax,88(%rsp)
 .cfi_escape	0x0f,0x06,0x77,0xd8,0x00,0x06,0x23,0x08
-.Lprologue_avx:
+LOCAL_LABEL(prologue_avx):
 
 	vzeroupper
 	movl	0(%rdi),%eax
@@ -2792,9 +2783,9 @@ ENTRY_ALIGN(zfs_sha256_transform_avx, 64)
 	movl	28(%rdi),%r11d
 	vmovdqa	K256+512+32(%rip),%xmm8
 	vmovdqa	K256+512+64(%rip),%xmm9
-	jmp	.Lloop_avx
+	jmp	LOCAL_LABEL(loop_avx)
 .balign	16
-.Lloop_avx:
+LOCAL_LABEL(loop_avx):
 	vmovdqa	K256+512(%rip),%xmm7
 	vmovdqu	0(%rsi),%xmm0
 	vmovdqu	16(%rsi),%xmm1
@@ -2817,10 +2808,10 @@ ENTRY_ALIGN(zfs_sha256_transform_avx, 64)
 	xorl	%ecx,%edi
 	vmovdqa	%xmm7,48(%rsp)
 	movl	%r8d,%r13d
-	jmp	.Lavx_00_47
+	jmp	LOCAL_LABEL(avx_00_47)
 
 .balign	16
-.Lavx_00_47:
+LOCAL_LABEL(avx_00_47):
 	subq	$-128,%rbp
 	vpalignr	$4,%xmm0,%xmm1,%xmm4
 	shrdl	$14,%r13d,%r13d
@@ -3363,7 +3354,7 @@ ENTRY_ALIGN(zfs_sha256_transform_avx, 64)
 	addl	%eax,%r14d
 	vmovdqa	%xmm6,48(%rsp)
 	cmpb	$0,131(%rbp)
-	jne	.Lavx_00_47
+	jne	LOCAL_LABEL(avx_00_47)
 	shrdl	$14,%r13d,%r13d
 	movl	%r14d,%eax
 	movl	%r9d,%r12d
@@ -3803,7 +3794,7 @@ ENTRY_ALIGN(zfs_sha256_transform_avx, 64)
 	movl	%r9d,20(%rdi)
 	movl	%r10d,24(%rdi)
 	movl	%r11d,28(%rdi)
-	jb	.Lloop_avx
+	jb	LOCAL_LABEL(loop_avx)
 
 	movq	88(%rsp),%rsi
 .cfi_def_cfa	%rsi,8
@@ -3822,7 +3813,7 @@ ENTRY_ALIGN(zfs_sha256_transform_avx, 64)
 .cfi_restore	%rbx
 	leaq	(%rsi),%rsp
 .cfi_def_cfa_register	%rsp
-.Lepilogue_avx:
+LOCAL_LABEL(epilogue_avx):
 	RET
 .cfi_endproc
 SET_SIZE(zfs_sha256_transform_avx)
@@ -3855,7 +3846,7 @@ ENTRY_ALIGN(zfs_sha256_transform_avx2, 64)
 	movq	%rdx,64+16(%rsp)
 	movq	%rax,88(%rsp)
 .cfi_escape	0x0f,0x06,0x77,0xd8,0x00,0x06,0x23,0x08
-.Lprologue_avx2:
+LOCAL_LABEL(prologue_avx2):
 
 	vzeroupper
 	subq	$-64,%rsi
@@ -3872,9 +3863,9 @@ ENTRY_ALIGN(zfs_sha256_transform_avx2, 64)
 	movl	28(%rdi),%r11d
 	vmovdqa	K256+512+32(%rip),%ymm8
 	vmovdqa	K256+512+64(%rip),%ymm9
-	jmp	.Loop_avx2
+	jmp	LOCAL_LABEL(oop_avx2)
 .balign	16
-.Loop_avx2:
+LOCAL_LABEL(oop_avx2):
 	vmovdqa	K256+512(%rip),%ymm7
 	vmovdqu	-64+0(%rsi),%xmm0
 	vmovdqu	-64+16(%rsi),%xmm1
@@ -3913,10 +3904,10 @@ ENTRY_ALIGN(zfs_sha256_transform_avx2, 64)
 	vmovdqa	%ymm7,32(%rsp)
 	movl	%r9d,%r12d
 	subq	$-32*4,%rbp
-	jmp	.Lavx2_00_47
+	jmp	LOCAL_LABEL(avx2_00_47)
 
 .balign	16
-.Lavx2_00_47:
+LOCAL_LABEL(avx2_00_47):
 	leaq	-64(%rsp),%rsp
 .cfi_escape	0x0f,0x05,0x77,0x38,0x06,0x23,0x08
 
@@ -4441,7 +4432,7 @@ ENTRY_ALIGN(zfs_sha256_transform_avx2, 64)
 	vmovdqa	%ymm6,32(%rsp)
 	leaq	128(%rbp),%rbp
 	cmpb	$0,3(%rbp)
-	jne	.Lavx2_00_47
+	jne	LOCAL_LABEL(avx2_00_47)
 	addl	0+64(%rsp),%r11d
 	andl	%r8d,%r12d
 	rorxl	$25,%r8d,%r13d
@@ -4850,15 +4841,15 @@ ENTRY_ALIGN(zfs_sha256_transform_avx2, 64)
 	movl	%r11d,28(%rdi)
 
 	cmpq	80(%rbp),%rsi
-	je	.Ldone_avx2
+	je	LOCAL_LABEL(done_avx2)
 
 	xorl	%r14d,%r14d
 	movl	%ebx,%edi
 	xorl	%ecx,%edi
 	movl	%r9d,%r12d
-	jmp	.Lower_avx2
+	jmp	LOCAL_LABEL(ower_avx2)
 .balign	16
-.Lower_avx2:
+LOCAL_LABEL(ower_avx2):
 	addl	0+16(%rbp),%r11d
 	andl	%r8d,%r12d
 	rorxl	$25,%r8d,%r13d
@@ -5053,7 +5044,7 @@ ENTRY_ALIGN(zfs_sha256_transform_avx2, 64)
 	movl	%r9d,%r12d
 	leaq	-64(%rbp),%rbp
 	cmpq	%rsp,%rbp
-	jae	.Lower_avx2
+	jae	LOCAL_LABEL(ower_avx2)
 
 	movq	512(%rsp),%rdi
 	addl	%r14d,%eax
@@ -5084,13 +5075,13 @@ ENTRY_ALIGN(zfs_sha256_transform_avx2, 64)
 	movl	%r10d,24(%rdi)
 	movl	%r11d,28(%rdi)
 
-	jbe	.Loop_avx2
+	jbe	LOCAL_LABEL(oop_avx2)
 	leaq	(%rsp),%rbp
 
 
 .cfi_escape	0x0f,0x06,0x76,0xd8,0x00,0x06,0x23,0x08
 
-.Ldone_avx2:
+LOCAL_LABEL(done_avx2):
 	movq	88(%rbp),%rsi
 .cfi_def_cfa	%rsi,8
 	vzeroupper
@@ -5108,7 +5099,7 @@ ENTRY_ALIGN(zfs_sha256_transform_avx2, 64)
 .cfi_restore	%rbx
 	leaq	(%rsi),%rsp
 .cfi_def_cfa_register	%rsp
-.Lepilogue_avx2:
+LOCAL_LABEL(epilogue_avx2):
 	RET
 .cfi_endproc
 SET_SIZE(zfs_sha256_transform_avx2)

--- a/module/icp/asm-x86_64/sha2/sha512-x86_64.S
+++ b/module/icp/asm-x86_64/sha2/sha512-x86_64.S
@@ -22,15 +22,6 @@
 
 #if defined(__x86_64)
 
-#if defined(__APPLE__) && (__clang_major__ >= 16)
-// There is a bug in Xcode 16.0
-// let sadd #if version == here?
-#define cfi_restore set ignore,
-#define cfi_def_cfa_register set ignore,
-#define cfi_def_cfa set ignore,nothing #
-#define cfi_escape set ignore,nothing #
-#endif
-
 #define _ASM
 #include <sys/asm_linkage.h>
 #include <sys/frame.h>
@@ -149,7 +140,7 @@ ENTRY_ALIGN(zfs_sha512_transform_x64, 16)
 	movq	%rdx,128+16(%rsp)
 	movq	%rax,152(%rsp)
 .cfi_escape	0x0f,0x06,0x77,0x98,0x01,0x06,0x23,0x08
-.Lprologue:
+LOCAL_LABEL(prologue):
 	movq	0(%rdi),%rax
 	movq	8(%rdi),%rbx
 	movq	16(%rdi),%rcx
@@ -158,9 +149,9 @@ ENTRY_ALIGN(zfs_sha512_transform_x64, 16)
 	movq	40(%rdi),%r9
 	movq	48(%rdi),%r10
 	movq	56(%rdi),%r11
-	jmp	.Lloop
+	jmp	LOCAL_LABEL(loop)
 .balign	16
-.Lloop:
+LOCAL_LABEL(loop):
 	movq	%rbx,%rdi
 	leaq	K512(%rip),%rbp
 	xorq	%rcx,%rdi
@@ -675,9 +666,9 @@ ENTRY_ALIGN(zfs_sha512_transform_x64, 16)
 	addq	%r12,%r8
 	addq	%r12,%rax
 	leaq	24(%rbp),%rbp
-	jmp	.Lrounds_16_xx
+	jmp	LOCAL_LABEL(rounds_16_xx)
 .balign	16
-.Lrounds_16_xx:
+LOCAL_LABEL(rounds_16_xx):
 	movq	8(%rsp),%r13
 	movq	112(%rsp),%r15
 	movq	%r13,%r12
@@ -1431,7 +1422,7 @@ ENTRY_ALIGN(zfs_sha512_transform_x64, 16)
 	addq	%r12,%rax
 	leaq	24(%rbp),%rbp
 	cmpb	$0,7(%rbp)
-	jnz	.Lrounds_16_xx
+	jnz	LOCAL_LABEL(rounds_16_xx)
 	movq	128+0(%rsp),%rdi
 	addq	%r14,%rax
 	leaq	128(%rsi),%rsi
@@ -1452,7 +1443,7 @@ ENTRY_ALIGN(zfs_sha512_transform_x64, 16)
 	movq	%r9,40(%rdi)
 	movq	%r10,48(%rdi)
 	movq	%r11,56(%rdi)
-	jb	.Lloop
+	jb	LOCAL_LABEL(loop)
 	movq	152(%rsp),%rsi
 .cfi_def_cfa	%rsi,8
 	movq	-48(%rsi),%r15
@@ -1469,7 +1460,7 @@ ENTRY_ALIGN(zfs_sha512_transform_x64, 16)
 .cfi_restore	%rbx
 	leaq	(%rsi),%rsp
 .cfi_def_cfa_register	%rsp
-.Lepilogue:
+LOCAL_LABEL(epilogue):
 	RET
 .cfi_endproc
 SET_SIZE(zfs_sha512_transform_x64)
@@ -1501,7 +1492,7 @@ ENTRY_ALIGN(zfs_sha512_transform_avx, 64)
 	movq	%rdx,128+16(%rsp)
 	movq	%rax,152(%rsp)
 .cfi_escape	0x0f,0x06,0x77,0x98,0x01,0x06,0x23,0x08
-.Lprologue_avx:
+LOCAL_LABEL(prologue_avx):
 
 	vzeroupper
 	movq	0(%rdi),%rax
@@ -1512,9 +1503,9 @@ ENTRY_ALIGN(zfs_sha512_transform_avx, 64)
 	movq	40(%rdi),%r9
 	movq	48(%rdi),%r10
 	movq	56(%rdi),%r11
-	jmp	.Lloop_avx
+	jmp	LOCAL_LABEL(loop_avx)
 .balign	16
-.Lloop_avx:
+LOCAL_LABEL(loop_avx):
 	vmovdqa	K512+1280(%rip),%xmm11
 	vmovdqu	0(%rsi),%xmm0
 	leaq	K512+128(%rip),%rbp
@@ -1553,10 +1544,10 @@ ENTRY_ALIGN(zfs_sha512_transform_avx, 64)
 	xorq	%rcx,%rdi
 	vmovdqa	%xmm11,112(%rsp)
 	movq	%r8,%r13
-	jmp	.Lavx_00_47
+	jmp	LOCAL_LABEL(avx_00_47)
 
 .balign	16
-.Lavx_00_47:
+LOCAL_LABEL(avx_00_47):
 	addq	$256,%rbp
 	vpalignr	$8,%xmm0,%xmm1,%xmm8
 	shrdq	$23,%r13,%r13
@@ -2175,7 +2166,7 @@ ENTRY_ALIGN(zfs_sha512_transform_avx, 64)
 	addq	%rax,%r14
 	vmovdqa	%xmm10,112(%rsp)
 	cmpb	$0,135(%rbp)
-	jne	.Lavx_00_47
+	jne	LOCAL_LABEL(avx_00_47)
 	shrdq	$23,%r13,%r13
 	movq	%r14,%rax
 	movq	%r9,%r12
@@ -2615,7 +2606,7 @@ ENTRY_ALIGN(zfs_sha512_transform_avx, 64)
 	movq	%r9,40(%rdi)
 	movq	%r10,48(%rdi)
 	movq	%r11,56(%rdi)
-	jb	.Lloop_avx
+	jb	LOCAL_LABEL(loop_avx)
 
 	movq	152(%rsp),%rsi
 .cfi_def_cfa	%rsi,8
@@ -2634,7 +2625,7 @@ ENTRY_ALIGN(zfs_sha512_transform_avx, 64)
 .cfi_restore	%rbx
 	leaq	(%rsi),%rsp
 .cfi_def_cfa_register	%rsp
-.Lepilogue_avx:
+LOCAL_LABEL(epilogue_avx):
 	RET
 .cfi_endproc
 SET_SIZE(zfs_sha512_transform_avx)
@@ -2667,7 +2658,7 @@ ENTRY_ALIGN(zfs_sha512_transform_avx2, 64)
 	movq	%rdx,128+16(%rsp)
 	movq	%rax,152(%rsp)
 .cfi_escape	0x0f,0x06,0x77,0x98,0x01,0x06,0x23,0x08
-.Lprologue_avx2:
+LOCAL_LABEL(prologue_avx2):
 
 	vzeroupper
 	subq	$-128,%rsi
@@ -2682,9 +2673,9 @@ ENTRY_ALIGN(zfs_sha512_transform_avx2, 64)
 	movq	40(%rdi),%r9
 	movq	48(%rdi),%r10
 	movq	56(%rdi),%r11
-	jmp	.Loop_avx2
+	jmp	LOCAL_LABEL(oop_avx2)
 .balign	16
-.Loop_avx2:
+LOCAL_LABEL(oop_avx2):
 	vmovdqu	-128(%rsi),%xmm0
 	vmovdqu	-128+16(%rsi),%xmm1
 	vmovdqu	-128+32(%rsi),%xmm2
@@ -2743,10 +2734,10 @@ ENTRY_ALIGN(zfs_sha512_transform_avx2, 64)
 	vmovdqa	%ymm11,96(%rsp)
 	movq	%r9,%r12
 	addq	$32*8,%rbp
-	jmp	.Lavx2_00_47
+	jmp	LOCAL_LABEL(avx2_00_47)
 
 .balign	16
-.Lavx2_00_47:
+LOCAL_LABEL(avx2_00_47):
 	leaq	-128(%rsp),%rsp
 .cfi_escape	0x0f,0x06,0x77,0xf8,0x00,0x06,0x23,0x08
 
@@ -3347,7 +3338,7 @@ ENTRY_ALIGN(zfs_sha512_transform_avx2, 64)
 	vmovdqa	%ymm10,96(%rsp)
 	leaq	256(%rbp),%rbp
 	cmpb	$0,-121(%rbp)
-	jne	.Lavx2_00_47
+	jne	LOCAL_LABEL(avx2_00_47)
 	addq	0+128(%rsp),%r11
 	andq	%r8,%r12
 	rorxq	$41,%r8,%r13
@@ -3756,15 +3747,15 @@ ENTRY_ALIGN(zfs_sha512_transform_avx2, 64)
 	movq	%r11,56(%rdi)
 
 	cmpq	144(%rbp),%rsi
-	je	.Ldone_avx2
+	je	LOCAL_LABEL(done_avx2)
 
 	xorq	%r14,%r14
 	movq	%rbx,%rdi
 	xorq	%rcx,%rdi
 	movq	%r9,%r12
-	jmp	.Lower_avx2
+	jmp	LOCAL_LABEL(ower_avx2)
 .balign	16
-.Lower_avx2:
+LOCAL_LABEL(ower_avx2):
 	addq	0+16(%rbp),%r11
 	andq	%r8,%r12
 	rorxq	$41,%r8,%r13
@@ -3959,7 +3950,7 @@ ENTRY_ALIGN(zfs_sha512_transform_avx2, 64)
 	movq	%r9,%r12
 	leaq	-128(%rbp),%rbp
 	cmpq	%rsp,%rbp
-	jae	.Lower_avx2
+	jae	LOCAL_LABEL(ower_avx2)
 
 	movq	1280(%rsp),%rdi
 	addq	%r14,%rax
@@ -3990,12 +3981,12 @@ ENTRY_ALIGN(zfs_sha512_transform_avx2, 64)
 	movq	%r10,48(%rdi)
 	movq	%r11,56(%rdi)
 
-	jbe	.Loop_avx2
+	jbe	LOCAL_LABEL(oop_avx2)
 	leaq	(%rsp),%rbp
 
 .cfi_escape	0x0f,0x06,0x76,0x98,0x01,0x06,0x23,0x08
 
-.Ldone_avx2:
+LOCAL_LABEL(done_avx2):
 	movq	152(%rbp),%rsi
 .cfi_def_cfa	%rsi,8
 	vzeroupper
@@ -4013,7 +4004,7 @@ ENTRY_ALIGN(zfs_sha512_transform_avx2, 64)
 .cfi_restore	%rbx
 	leaq	(%rsi),%rsp
 .cfi_def_cfa_register	%rsp
-.Lepilogue_avx2:
+LOCAL_LABEL(epilogue_avx2):
 	RET
 .cfi_endproc
 SET_SIZE(zfs_sha512_transform_avx2)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

There was some discussion on https://github.com/openzfsonosx/openzfs-fork/commit/9b7c23a97757bbfd302a8b70adae9f63511d51e2 about compilation issues in assembly files with CFI directives. This PR implements the proposed fix mentioned in the thread .

### Description
<!--- Describe your changes in detail -->

On ELF-based targets (including Linux and FreeBSD), the `.L` prefix is used for assembly labels which should not generate a symbol table entry. Mach-O targets (notably macOS) use a different prefix (`L`) for local labels. While most of the assembly files in icp use the `.L` prefix, they can usually be compiled for macOS with minimal changes. However, labels using the `.L` prefix will not be treated as local labels.

[Recent versions of LLVM no longer allow non-local labels in between `.cfi_startproc` and `.cfi_endproc` on Mach-O targets][1]. Specifically, assembly files which use `.cfi_adjust_cfa_offset` and `.L`-prefixed labels no longer compile on macOS with recent versions of Clang.

Define a new LOCAL_LABEL macro in asm_linkage.h to define local labels with the right prefix on each OS. Also update some icp assembly files which use `.cfi_adjust_cfa_offset` to use the LOCAL_LABEL macro. The replacements were done with the following sed command:

```
sed -i -E 's|\.L([a-zA-Z0-9_]+)|LOCAL_LABEL\(\1\)|g'
```

The following nm command was used to find `.L`-prefixed entries in the symbol table:

```
nm macos_zfs | grep '\.L'
```

[1]: https://reviews.llvm.org/D153167

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).