### PR TITLE
macOS: check zil_commit() result in zfs_vfs_sync()

### DIFF
--- a/module/os/macos/zfs/zfs_vfsops.c
+++ b/module/os/macos/zfs/zfs_vfsops.c
@@ -262,10 +262,12 @@ zfs_vfs_sync(struct mount *vfsp, __unused int waitfor,
 		}
 
 		if (zfsvfs->z_log != NULL)
-			zil_commit(zfsvfs->z_log, 0);
+			error = zil_commit(zfsvfs->z_log, 0);
 
 		zfs_exit(zfsvfs, FTAG);
 
+		if (error != 0)
+			return (error);
 	} else {
 		/*
 		 * Sync all ZFS filesystems. This is what happens when you


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I noticed the following warning during compilation:

```
module/os/macos/zfs/zfs_vfsops.c:265:4: warning: ignoring return value of function declared with 'warn_unused_result' attribute [-Wunused-result]
  265 |                         zil_commit(zfsvfs->z_log, 0);
      |                         ^~~~~~~~~~ ~~~~~~~~~~~~~~~~
```

### Description
<!--- Describe your changes in detail -->

Clang complains that `zfs_vfs_sync()` ignores the return value of `zil_commit()`. Update it to handle errors in the same manner as `zfs_sync()` on FreeBSD.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
