### PR TITLE
macOS: disable interrupts in kpreempt macros

### DIFF
--- a/include/os/macos/spl/sys/Makefile.am
+++ b/include/os/macos/spl/sys/Makefile.am
@@ -7,6 +7,7 @@ KERNEL_H = \
 	$(top_srcdir)/include/os/macos/spl/sys/console.h \
 	$(top_srcdir)/include/os/macos/spl/sys/cred.h \
 	$(top_srcdir)/include/os/macos/spl/sys/debug.h \
+	$(top_srcdir)/include/os/macos/spl/sys/disp.h \
 	$(top_srcdir)/include/os/macos/spl/sys/errno.h \
 	$(top_srcdir)/include/os/macos/spl/sys/fcntl.h \
 	$(top_srcdir)/include/os/macos/spl/sys/file.h \

--- a/include/os/macos/spl/sys/disp.h
+++ b/include/os/macos/spl/sys/disp.h
@@ -22,4 +22,17 @@
 #ifndef _SPL_DISP_H
 #define	_SPL_DISP_H
 
+#define	KPREEMPT_SYNC		(-1)
+
+#define	kpreempt(unused)	(void) thread_block(THREAD_CONTINUE_NULL)
+
+/*
+ * XNU doesn't export _disable_preemption() or _enable_preemption() so we use
+ * ml_set_interrupts_enabled() instead.
+ */
+extern boolean_t ml_set_interrupts_enabled(boolean_t);
+
+#define	kpreempt_disable()	ml_set_interrupts_enabled(false)
+#define	kpreempt_enable()	ml_set_interrupts_enabled(true)
+
 #endif

--- a/include/os/macos/spl/sys/thread.h
+++ b/include/os/macos/spl/sys/thread.h
@@ -178,12 +178,6 @@ extern void spl_set_thread_latency(thread_t,
 #define	delay osx_delay
 extern void osx_delay(clock_t);
 
-#define	KPREEMPT_SYNC 0
-static inline void kpreempt(int flags)
-{
-	(void) thread_block(THREAD_CONTINUE_NULL);
-}
-
 static inline char *
 getcomm(void)
 {

--- a/include/os/macos/zfs/sys/zfs_context_os.h
+++ b/include/os/macos/zfs/sys/zfs_context_os.h
@@ -75,12 +75,6 @@ typedef struct spa_iokit spa_iokit_t;
 
 #define	noinline		__attribute__((noinline))
 
-/* really? */
-#define	kpreempt_disable()	((void)0)
-#define	kpreempt_enable()	((void)0)
-#define	cond_resched()	(void)thread_block(THREAD_CONTINUE_NULL);
-#define	schedule()	(void)thread_block(THREAD_CONTINUE_NULL);
-
 #define	current		curthread
 
 extern boolean_t ml_set_interrupts_enabled(boolean_t);

--- a/module/os/macos/spl/spl-kmem.c
+++ b/module/os/macos/spl/spl-kmem.c
@@ -33,6 +33,7 @@
 #include <sys/debug.h>
 #include <sys/cdefs.h>
 #include <sys/cmn_err.h>
+#include <sys/disp.h>
 #include <sys/param.h>
 #include <sys/kernel.h>
 #include <sys/kstat.h>

--- a/module/os/macos/zfs/zvol_os.c
+++ b/module/os/macos/zfs/zvol_os.c
@@ -887,7 +887,7 @@ out_mutex:
 
 	if (error == EINTR) {
 		error = ERESTART;
-		schedule();
+		(void) thread_block(THREAD_CONTINUE_NULL);
 	}
 	return (SET_ERROR(error));
 }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I took another look at #55 and noticed that `kpreempt_disable()` and `kpreempt_enable()` were defined as no-ops on macOS: https://github.com/openzfsonosx/openzfs-fork/blob/a9fc067789cbee3ee53dff785124edbb76863ff1/include/os/macos/zfs/sys/zfs_context_os.h#L78-L82

#14808 fixed some pool corruption issues on FreeBSD by disabling preemption so I suspected that the no-ops may be partially responsible for the various BLAKE3 panics. I'm not an XNU expert (feel free to correct me!) but disabling interrupts appears to also disable preemption (at least on x86_64). I no longer observe the BLAKE3 panics with this patch.

Note that ARM64 likely needs an additional change to restore the `kpreempt_disable()`/`kpreempt_enable()` calls in `abd_checksum_blake3_native()` (though I have not tested this):

https://github.com/openzfsonosx/openzfs-fork/blob/a9fc067789cbee3ee53dff785124edbb76863ff1/module/zfs/blake3_zfs.c#L53-L64

### Description
<!--- Describe your changes in detail -->

The macOS versions of `kpreempt_disable()` and `kpreempt_enable()` are currently defined as no-ops, which may cause preemption to occur in critical sections. The corresponding `_disable_preemption()` and `_enable_preemption()` functions in XNU are not exported to KEXTs and cannot be used in ZFS. Instead, use `ml_set_interrupts_enabled(false)` to implement `kpreempt_disable()` and `ml_set_interrupts_enabled(true)` to implement `kpreempt_enable()`. Additionally move the macro definitions to sys/disp.h to match Linux and FreeBSD. The `schedule()` and `cond_sched()` macros were removed to match #13845.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

I used the following script to reproduce #55 in a VM running macOS 15 (x86_64):

```
sysctl kstat.zfs.darwin.tunable.zfs.blake3_impl=generic
truncate -s +4G /tmp/zpool
zpool create -O checksum=blake3 zpool /tmp/zpool
while true; do
  fio --name=randrw --rwmixread=70 --filename=/Volumes/zpool/data --direct=1 --ioengine=posixaio --rw=randrw --bs=64k --direct=1 --size=512M --numjobs=8 --runtime=300
done
```

With 2.4.1rc4 this would panic in less than a minute. I no longer see any panics with this change.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
