### PR TITLE
macOS: return ENOENT for absent xattr directory

### DIFF
--- a/module/os/macos/zfs/zfs_dir.c
+++ b/module/os/macos/zfs/zfs_dir.c
@@ -1148,7 +1148,7 @@ zfs_get_xattrdir(znode_t *zp, znode_t **xzpp, cred_t *cr, int flags)
 	 * or created.
 	 */
 	if (!(flags & CREATE_XATTR_DIR) && zp->z_xattr_dir_absent)
-		return (SET_ERROR(ENOATTR));
+		return (SET_ERROR(ENOENT));
 
 top:
 	error = zfs_dirent_lock(&dl, zp, "", &xzp, ZXATTR, NULL, NULL);


### PR DESCRIPTION
### Motivation and Context

Commit [f3c18ddd](https://github.com/openzfsonosx/openzfs-fork/commit/f3c18ddd30200ed3c74d51e9295089111cfe50de) added a cached fast path in `zfs_get_xattrdir()` that returns `ENOATTR` when no xattr directory exists. The uncached path returns `ENOENT`, and `zpl_xattr_list_dir()` only translates `ENOENT` into an empty xattr list. Once the absence cache is populated, `listxattr(2)` therefore leaks `ENOATTR` to macOS.

Apple `cp -p` then fails with:

```
cp: ... could not copy extended attributes ...: Attribute not found
```

### Description

Return `ENOENT` from the cached path. This matches the uncached path and the [original upstream OpenZFS implementation](https://github.com/openzfs/zfs/commit/68a5d2f1dd4371a21bde0931aaa063785585f697).

### How Has This Been Tested?

Reproduced on macOS 26.6.1 with OpenZFS 2.4.3-rc2:

- `listxattr()` on a ZFS file with no extended attributes returns `-1` / `ENOATTR`.
- `/bin/cp -p` copies the data but exits 1 with the error above.
- `/bin/cp -pX` exits 0, isolating extended-attribute enumeration.
- The patched 2.4.3-rc2 source builds successfully.

The patched kext was not runtime-loaded because the custom build is unsigned and SIP remains enabled.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist

- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [contributing document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain `Signed-off-by`.
