### PR TITLE
macOS: give spl_free_thread a void * argument for C23

### DIFF
--- a/module/os/macos/spl/spl-kmem.c
+++ b/module/os/macos/spl/spl-kmem.c
@@ -4647,9 +4647,11 @@ spl_maybe_send_large_pressure(uint64_t now, uint64_t minutes, boolean_t full)
 }
 
 static void
-spl_free_thread()
+spl_free_thread(void *notused)
 {
 	callb_cpr_t cpr;
+
+	(void) notused;
 
 	CALLB_CPR_INIT(&cpr, &spl_free_thread_lock, callb_generic_cpr, FTAG);
 


### PR DESCRIPTION
## Summary
Current Xcode/clang defaults the macOS kext to C23. In C23, `void spl_free_thread()` means no arguments, but `thread_create` takes `thread_func_t` (`void (*)(void *)`). That fails the kext build with `-Wincompatible-function-pointer-types`.

Give `spl_free_thread` a `void *notused` argument, matching `arc_reclaim_thread`, `zfsctl_unmount_thread`, and the other macOS kext threads.

No behavior change: the thread is still created with argument `0`, and the body still ignores it.

## Test plan
- [x] Follow `.github/workflows/macos-build.yaml` (`./autogen.sh`, `./configure` with Homebrew gettext/openssl flags, `make -j`)
- [x] Confirm the previous error in `module/os/macos/spl/spl-kmem.c` is gone
- [x] Confirm `make` completes and produces `module/os/macos/zfs.kext`