### PR TITLE
macOS: advance XNU uio across iovecs in zfs_uioskip/zfs_uio_advance

### DIFF
--- a/include/os/macos/spl/sys/uio.h
+++ b/include/os/macos/spl/sys/uio.h
@@ -188,11 +188,13 @@ zfs_uio_setsoffset(zfs_uio_t *uio, offset_t off)
 	uio->uio_soffset = off;
 }
 
+extern void zfs_uio_xnu_skip(struct uio *, size_t);
+
 static inline void
 zfs_uio_advance(zfs_uio_t *uio, size_t size)
 {
 	if (uio->uio_iov == NULL) {
-		uio_update(uio->uio_xnu, size);
+		zfs_uio_xnu_skip(uio->uio_xnu, size);
 	} else {
 		uio->uio_resid -= size;
 		uio->uio_loffset += size;

--- a/module/os/macos/spl/spl-uio.c
+++ b/module/os/macos/spl/spl-uio.c
@@ -121,11 +121,37 @@ zfs_uiocopy(const char *p, size_t n, enum uio_rw rw, zfs_uio_t *uio,
 	return (result);
 }
 
+/*
+ * Advance an XNU uio by n bytes across iovec boundaries.
+ *
+ * uio_update() advances only the current iovec, but updates the residual
+ * and file offset by the requested count. Limit each update to the
+ * current iovec's remaining length so subsequent I/O resumes at the
+ * correct position.
+ */
+void
+zfs_uio_xnu_skip(struct uio *xuio, size_t n)
+{
+	while (n > 0 && uio_iovcnt(xuio) > 0) {
+		user_size_t cur = uio_curriovlen(xuio);
+
+		if (cur == 0) {
+			/* Skip over empty iovecs. */
+			uio_update(xuio, 0);
+			continue;
+		}
+		if (cur > n)
+			cur = n;
+		uio_update(xuio, cur);
+		n -= cur;
+	}
+}
+
 void
 zfs_uioskip(zfs_uio_t *uio, size_t n)
 {
 	if (uio->uio_iov == NULL) {
-		uio_update(uio->uio_xnu, n);
+		zfs_uio_xnu_skip(uio->uio_xnu, n);
 	} else {
 		if (n > uio->uio_resid)
 			return;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

### Motivation and Context
Multi-iovec writes crossing record boundaries can silently corrupt data on macOS ZFS, causing failures such as Electron Builder reporting “app.asar is corrupted.”

### Description
XNU’s uio_update() advances only the current iovec, even when the requested count spans multiple iovecs. Add a helper that advances across iovecs correctly and use it in zfs_uioskip() and zfs_uio_advance().

### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

Tested on macOS 26.6.2 (arm64), with the fix cherry-picked onto zfs-macOS-2.4.1, using recordsize=128K with default settings and with compression=zstd, dedup=blake3, and sync=disabled.

Manual Python probes verified file contents against the input:
| Shape | Stock 2.4.1 | Patched |
|---|---|---|
| `[8 B, 6 MB]` (asar header pattern) | corrupt | OK |
| `[8 B, 200 KB]` | corrupt | OK |
| 64 KiB x 10 (iovec ends exactly on the record boundary) | corrupt | OK |
| 4 KiB x 100 | corrupt | OK |
| `[8 B, 0, 0, 300 KB]` (empty iovecs) | corrupt | OK |
| `[6 MB]` single iovec | OK | OK |
| `[8 B, 120 KB]` (under one record) | OK | OK |
| `pwritev` + `readv` round trip | corrupt | OK |

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Quality assurance (non-breaking change which makes the code more robust against bugs)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
